### PR TITLE
docs: Add specification for encrypt API in the Structured En…

### DIFF
--- a/specification/structured-encryption/decrypt-structure.md
+++ b/specification/structured-encryption/decrypt-structure.md
@@ -26,14 +26,14 @@ This document describes the behavior by which a [Structured Data](./structures.m
 which has been [encrypted](./encrypt-structure.md) is decrypted.
 We define decryption over this [Structured Data](./structures.md#structured-data) to mean that
 we obtain back the original Structured Data,
-and ensure integrity and authenticity is ensured over a set of of [Terminal Data](./structures.md#terminal-data).
+and ensure integrity and authenticity is ensured over a set of [Terminal Data](./structures.md#terminal-data).
 
 ## Input
 
 The following inputs to this behavior are REQUIRED:
 
 - [Encrypted Structured Data](#encrypted-structured-data)
-- Either a [Cryptographic Materials Manager (CMM)](#cmm) or a [Keyring](#keyring)
+- [Cryptographic Materials Manager (CMM)](#cmm)
 
 The following inputs to this behavior MUST be OPTIONAL:
 
@@ -47,10 +47,6 @@ The [Structured Data](./structures.md#structured-data) to be decrypted.
 ### CMM
 
 A CMM that implements the [CMM interface](https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/cmm-interface.md).
-
-### Keyring
-
-A Keyring that implements the [keyring interface](https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/keyring-interface.md).
 
 ### Encryption Context
 
@@ -72,17 +68,6 @@ otherwise decryption MUST fail.
 
 The decrypted form of the [input Encrypted Structured Data](#encrypted-structured-data),
 decrypted according to the [behavior specified below](#behavior).
-
-### Parsed Header
-
-A structure containing information derived from the header of the [output Encrypted Structured Data](#encrypted-structured-data).
-This structure MUST include:
-- The [Message Format Version](#TODO-truss-header)
-- The [Message ID](#TODO-truss-header)
-- The [Algorithm Suite](#TODO-truss-header)
-- The [Crypto Schema](#TODO-truss-header)
-- The stored [Encryption Context](#TODO-truss-header)
-- The [Encrypted Data Keys](#TODO-truss-header)
 
 ## Behavior
 

--- a/specification/structured-encryption/structures.md
+++ b/specification/structured-encryption/structures.md
@@ -53,27 +53,30 @@ during the Encrypt Structure and Decrypt Structure operations.
 
 During [Encrypt Structure](encrypt-structure.md#encrypt-structure),
 ENCRYPT_AND_SIGN signifies that the [Terminal Value](#terminal-value) in the [Terminal Data](#terminal-data)
-MUST be encrypted in the resulting encrypted [Structured Data](#structured-data),
-and the [Terminal Data](#terminal-data) included as part of the signature calculation.
+MUST be encrypted in the resulting encrypted [Structured Data](#structured-data).
+ENCRYPT_AND_SIGN also signifies that the [Terminal Data](#terminal-data)
+MUST be included as part of the signature calculation.
 
 During [Decrypt Structure](decrypt-structure.md#decrypt-structure),
 ENCRYPT_AND_SIGN  signifies that the [Terminal Value](#terminal-value) in the [Terminal Data](#terminal-data)
-MUST be attempted to be decrypted, and the Terminal Data included as part of the signature verification calculation.
+MUST be attempted to be decrypted.
+ENCRYPT_AND_SIGN also signifies that the [Terminal Data](#terminal-data)
+MUST be included as part of the signature verification calculation.
 
 ##### SIGN_ONLY
 
 During Encrypt Structure,
-signifies that the [Terminal Data](#terminal-data) MUST be included as part of the signature calculation.
+SIGN_ONLY signifies that the [Terminal Data](#terminal-data) MUST be included as part of the signature calculation.
 
 During Decrypt Structure,
-signifies that the [Terminal Data](#terminal-data) MUST be included as part of the signature verification calculation.
+SIGN_ONLY signifies that the [Terminal Data](#terminal-data) MUST be included as part of the signature verification calculation.
 
 ##### IGNORE
 
-Signifies that the [Terminal Data](#terminal-data) MUST NOT be included in any signature calculation as part of
+IGNORE signifies that the [Terminal Data](#terminal-data) MUST NOT be included in any signature calculation as part of
 Encrypt Structure or Decrypt Structure.
 
-Additionally signifies that the [Terminal Data](#terminal-data) on output MUST equal that Terminal Data on input for
+IGNORE additionally signifies that the [Terminal Data](#terminal-data) on output MUST equal that Terminal Data on input for
 Encrypt Structure and Decrypt Structure.
 
 ### Crypto Schema
@@ -83,15 +86,7 @@ during encryption and decryption, based on that Terminal Data's location within 
 
 ### Encryption Context
 
-The Encryption Context is a key-value mapping of arbitrary, non-secret, UTF-8 encoded strings.
-It is used during encryption and decryption to provide additional authenticated data (AAD).
-
-Users SHOULD use the encryption context to store:
-
-- Non-secret data that MUST remain associated with the encrypted [Structured Data](#structured-data).
-- Data that is useful in logging and tracking, such as data about the file type, purpose, or ownership.
-
-Users MUST NOT use the encryption context to store secret data.
+TODO: Link directly to the MPL definition once it is more generalized.
 
 ### Structured Data
 


### PR DESCRIPTION
…cryption Library

Contains a specification for EncryptStructure, a stub for DecryptStructure, and specifications for important structures/terms.

This specification links to more specific truss specification which does not yet exist in this repo (refer to https://code.amazon.com/packages/CryptoolsTrussDesignDocs/trees/mainline/--/design). My goal is to leave this out of scope for this PR, and to gradually pull in those details in subsequent PRs. This specifications also links to changes that still need to be made to the MPL spec, such as new algorithm suites. Those changes should also be considered out of scope.

Introducing duvet to this repo is similarly out of scope.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
