### PR TITLE
feat: Add 'originalInput' param to middleware interface

### DIFF
--- a/DynamoDbEncryptionMiddlewareInternal/Model/AwsCryptographyDynamoDbEncryptionMiddlewareInternalTypes.dfy
+++ b/DynamoDbEncryptionMiddlewareInternal/Model/AwsCryptographyDynamoDbEncryptionMiddlewareInternalTypes.dfy
@@ -25,7 +25,8 @@ include "../../private-aws-encryption-sdk-dafny-staging/StandardLibrary/src/Inde
  nameonly transformedInput: ComAmazonawsDynamodbTypes.BatchExecuteStatementInput
  )
  datatype BatchExecuteStatementOutputTransformInput = | BatchExecuteStatementOutputTransformInput (
- nameonly sdkOutput: ComAmazonawsDynamodbTypes.BatchExecuteStatementOutput
+ nameonly sdkOutput: ComAmazonawsDynamodbTypes.BatchExecuteStatementOutput ,
+ nameonly originalInput: ComAmazonawsDynamodbTypes.BatchExecuteStatementInput
  )
  datatype BatchExecuteStatementOutputTransformOutput = | BatchExecuteStatementOutputTransformOutput (
  nameonly transformedOutput: ComAmazonawsDynamodbTypes.BatchExecuteStatementOutput
@@ -37,7 +38,8 @@ include "../../private-aws-encryption-sdk-dafny-staging/StandardLibrary/src/Inde
  nameonly transformedInput: ComAmazonawsDynamodbTypes.BatchGetItemInput
  )
  datatype BatchGetItemOutputTransformInput = | BatchGetItemOutputTransformInput (
- nameonly sdkOutput: ComAmazonawsDynamodbTypes.BatchGetItemOutput
+ nameonly sdkOutput: ComAmazonawsDynamodbTypes.BatchGetItemOutput ,
+ nameonly originalInput: ComAmazonawsDynamodbTypes.BatchGetItemInput
  )
  datatype BatchGetItemOutputTransformOutput = | BatchGetItemOutputTransformOutput (
  nameonly transformedOutput: ComAmazonawsDynamodbTypes.BatchGetItemOutput
@@ -49,7 +51,8 @@ include "../../private-aws-encryption-sdk-dafny-staging/StandardLibrary/src/Inde
  nameonly transformedInput: ComAmazonawsDynamodbTypes.BatchWriteItemInput
  )
  datatype BatchWriteItemOutputTransformInput = | BatchWriteItemOutputTransformInput (
- nameonly sdkOutput: ComAmazonawsDynamodbTypes.BatchWriteItemOutput
+ nameonly sdkOutput: ComAmazonawsDynamodbTypes.BatchWriteItemOutput ,
+ nameonly originalInput: ComAmazonawsDynamodbTypes.BatchWriteItemInput
  )
  datatype BatchWriteItemOutputTransformOutput = | BatchWriteItemOutputTransformOutput (
  nameonly transformedOutput: ComAmazonawsDynamodbTypes.BatchWriteItemOutput
@@ -61,7 +64,8 @@ include "../../private-aws-encryption-sdk-dafny-staging/StandardLibrary/src/Inde
  nameonly transformedInput: ComAmazonawsDynamodbTypes.DeleteItemInput
  )
  datatype DeleteItemOutputTransformInput = | DeleteItemOutputTransformInput (
- nameonly sdkOutput: ComAmazonawsDynamodbTypes.DeleteItemOutput
+ nameonly sdkOutput: ComAmazonawsDynamodbTypes.DeleteItemOutput ,
+ nameonly originalInput: ComAmazonawsDynamodbTypes.DeleteItemInput
  )
  datatype DeleteItemOutputTransformOutput = | DeleteItemOutputTransformOutput (
  nameonly transformedOutput: ComAmazonawsDynamodbTypes.DeleteItemOutput
@@ -559,7 +563,8 @@ include "../../private-aws-encryption-sdk-dafny-staging/StandardLibrary/src/Inde
  nameonly transformedInput: ComAmazonawsDynamodbTypes.ExecuteStatementInput
  )
  datatype ExecuteStatementOutputTransformInput = | ExecuteStatementOutputTransformInput (
- nameonly sdkOutput: ComAmazonawsDynamodbTypes.ExecuteStatementOutput
+ nameonly sdkOutput: ComAmazonawsDynamodbTypes.ExecuteStatementOutput ,
+ nameonly originalInput: ComAmazonawsDynamodbTypes.ExecuteStatementInput
  )
  datatype ExecuteStatementOutputTransformOutput = | ExecuteStatementOutputTransformOutput (
  nameonly transformedOutput: ComAmazonawsDynamodbTypes.ExecuteStatementOutput
@@ -571,7 +576,8 @@ include "../../private-aws-encryption-sdk-dafny-staging/StandardLibrary/src/Inde
  nameonly transformedInput: ComAmazonawsDynamodbTypes.ExecuteTransactionInput
  )
  datatype ExecuteTransactionOutputTransformInput = | ExecuteTransactionOutputTransformInput (
- nameonly sdkOutput: ComAmazonawsDynamodbTypes.ExecuteTransactionOutput
+ nameonly sdkOutput: ComAmazonawsDynamodbTypes.ExecuteTransactionOutput ,
+ nameonly originalInput: ComAmazonawsDynamodbTypes.ExecuteTransactionInput
  )
  datatype ExecuteTransactionOutputTransformOutput = | ExecuteTransactionOutputTransformOutput (
  nameonly transformedOutput: ComAmazonawsDynamodbTypes.ExecuteTransactionOutput
@@ -583,7 +589,8 @@ include "../../private-aws-encryption-sdk-dafny-staging/StandardLibrary/src/Inde
  nameonly transformedInput: ComAmazonawsDynamodbTypes.GetItemInput
  )
  datatype GetItemOutputTransformInput = | GetItemOutputTransformInput (
- nameonly sdkOutput: ComAmazonawsDynamodbTypes.GetItemOutput
+ nameonly sdkOutput: ComAmazonawsDynamodbTypes.GetItemOutput ,
+ nameonly originalInput: ComAmazonawsDynamodbTypes.GetItemInput
  )
  datatype GetItemOutputTransformOutput = | GetItemOutputTransformOutput (
  nameonly transformedOutput: ComAmazonawsDynamodbTypes.GetItemOutput
@@ -595,7 +602,8 @@ include "../../private-aws-encryption-sdk-dafny-staging/StandardLibrary/src/Inde
  nameonly transformedInput: ComAmazonawsDynamodbTypes.PutItemInput
  )
  datatype PutItemOutputTransformInput = | PutItemOutputTransformInput (
- nameonly sdkOutput: ComAmazonawsDynamodbTypes.PutItemOutput
+ nameonly sdkOutput: ComAmazonawsDynamodbTypes.PutItemOutput ,
+ nameonly originalInput: ComAmazonawsDynamodbTypes.PutItemInput
  )
  datatype PutItemOutputTransformOutput = | PutItemOutputTransformOutput (
  nameonly transformedOutput: ComAmazonawsDynamodbTypes.PutItemOutput
@@ -607,7 +615,8 @@ include "../../private-aws-encryption-sdk-dafny-staging/StandardLibrary/src/Inde
  nameonly transformedInput: ComAmazonawsDynamodbTypes.QueryInput
  )
  datatype QueryOutputTransformInput = | QueryOutputTransformInput (
- nameonly sdkOutput: ComAmazonawsDynamodbTypes.QueryOutput
+ nameonly sdkOutput: ComAmazonawsDynamodbTypes.QueryOutput ,
+ nameonly originalInput: ComAmazonawsDynamodbTypes.QueryInput
  )
  datatype QueryOutputTransformOutput = | QueryOutputTransformOutput (
  nameonly transformedOutput: ComAmazonawsDynamodbTypes.QueryOutput
@@ -619,7 +628,8 @@ include "../../private-aws-encryption-sdk-dafny-staging/StandardLibrary/src/Inde
  nameonly transformedInput: ComAmazonawsDynamodbTypes.ScanInput
  )
  datatype ScanOutputTransformInput = | ScanOutputTransformInput (
- nameonly sdkOutput: ComAmazonawsDynamodbTypes.ScanOutput
+ nameonly sdkOutput: ComAmazonawsDynamodbTypes.ScanOutput ,
+ nameonly originalInput: ComAmazonawsDynamodbTypes.ScanInput
  )
  datatype ScanOutputTransformOutput = | ScanOutputTransformOutput (
  nameonly transformedOutput: ComAmazonawsDynamodbTypes.ScanOutput
@@ -631,7 +641,8 @@ include "../../private-aws-encryption-sdk-dafny-staging/StandardLibrary/src/Inde
  nameonly transformedInput: ComAmazonawsDynamodbTypes.TransactGetItemsInput
  )
  datatype TransactGetItemsOutputTransformInput = | TransactGetItemsOutputTransformInput (
- nameonly sdkOutput: ComAmazonawsDynamodbTypes.TransactGetItemsOutput
+ nameonly sdkOutput: ComAmazonawsDynamodbTypes.TransactGetItemsOutput ,
+ nameonly originalInput: ComAmazonawsDynamodbTypes.TransactGetItemsInput
  )
  datatype TransactGetItemsOutputTransformOutput = | TransactGetItemsOutputTransformOutput (
  nameonly transformedOutput: ComAmazonawsDynamodbTypes.TransactGetItemsOutput
@@ -643,7 +654,8 @@ include "../../private-aws-encryption-sdk-dafny-staging/StandardLibrary/src/Inde
  nameonly transformedInput: ComAmazonawsDynamodbTypes.TransactWriteItemsInput
  )
  datatype TransactWriteItemsOutputTransformInput = | TransactWriteItemsOutputTransformInput (
- nameonly sdkOutput: ComAmazonawsDynamodbTypes.TransactWriteItemsOutput
+ nameonly sdkOutput: ComAmazonawsDynamodbTypes.TransactWriteItemsOutput ,
+ nameonly originalInput: ComAmazonawsDynamodbTypes.TransactWriteItemsInput
  )
  datatype TransactWriteItemsOutputTransformOutput = | TransactWriteItemsOutputTransformOutput (
  nameonly transformedOutput: ComAmazonawsDynamodbTypes.TransactWriteItemsOutput
@@ -655,7 +667,8 @@ include "../../private-aws-encryption-sdk-dafny-staging/StandardLibrary/src/Inde
  nameonly transformedInput: ComAmazonawsDynamodbTypes.UpdateItemInput
  )
  datatype UpdateItemOutputTransformInput = | UpdateItemOutputTransformInput (
- nameonly sdkOutput: ComAmazonawsDynamodbTypes.UpdateItemOutput
+ nameonly sdkOutput: ComAmazonawsDynamodbTypes.UpdateItemOutput ,
+ nameonly originalInput: ComAmazonawsDynamodbTypes.UpdateItemInput
  )
  datatype UpdateItemOutputTransformOutput = | UpdateItemOutputTransformOutput (
  nameonly transformedOutput: ComAmazonawsDynamodbTypes.UpdateItemOutput
@@ -707,7 +720,7 @@ include "../../private-aws-encryption-sdk-dafny-staging/StandardLibrary/src/Inde
  function method DefaultDynamoDbEncryptionMiddlewareInternalConfig(): DynamoDbEncryptionMiddlewareInternalConfig
  method DynamoDbEncryptionMiddlewareInternal(config: DynamoDbEncryptionMiddlewareInternalConfig := DefaultDynamoDbEncryptionMiddlewareInternalConfig())
  returns (res: Result<DynamoDbEncryptionMiddlewareInternalClient, Error>)
-  // TODO smithy->Dafny needs to generate the following
+ // TODO smithy->Dafny needs to generate the following
  ///// MANUAL UPDATE STARTS HERE
  requires
  var cmms := set cfg | cfg in config.tableEncryptionConfigs.Values && cfg.cmm.Some? :: cfg.cmm.value;

--- a/DynamoDbEncryptionMiddlewareInternal/Model/transforms.smithy
+++ b/DynamoDbEncryptionMiddlewareInternal/Model/transforms.smithy
@@ -29,7 +29,6 @@ use com.amazonaws.dynamodb#BatchExecuteStatementOutput
 use com.amazonaws.dynamodb#ExecuteTransactionInput
 use com.amazonaws.dynamodb#ExecuteTransactionOutput
 
-// TODO: OutputTransformInputs need a 'executedSDKInput' or similar for Scan Beacons)
 // TODO: Model passthrough APIs
 // TODO: Do we model an "unknown operation" somewhere, that just spits out an error?
 
@@ -56,6 +55,8 @@ operation PutItemOutputTransform {
 structure PutItemOutputTransformInput {
     @required
     sdkOutput: PutItemOutput,
+    @required
+    originalInput: PutItemInput,
 }
 
 structure PutItemOutputTransformOutput {
@@ -86,6 +87,8 @@ operation GetItemOutputTransform {
 structure GetItemOutputTransformInput {
     @required
     sdkOutput: GetItemOutput,
+    @required
+    originalInput: GetItemInput,
 }
 
 structure GetItemOutputTransformOutput {
@@ -116,6 +119,8 @@ operation BatchWriteItemOutputTransform {
 structure BatchWriteItemOutputTransformInput {
     @required
     sdkOutput: BatchWriteItemOutput,
+    @required
+    originalInput: BatchWriteItemInput,
 }
 
 structure BatchWriteItemOutputTransformOutput {
@@ -146,6 +151,8 @@ operation BatchGetItemOutputTransform {
 structure BatchGetItemOutputTransformInput {
     @required
     sdkOutput: BatchGetItemOutput,
+    @required
+    originalInput: BatchGetItemInput,
 }
 
 structure BatchGetItemOutputTransformOutput {
@@ -176,6 +183,8 @@ operation ScanOutputTransform {
 structure ScanOutputTransformInput {
     @required
     sdkOutput: ScanOutput,
+    @required
+    originalInput: ScanInput,
 }
 
 structure ScanOutputTransformOutput {
@@ -206,6 +215,8 @@ operation QueryOutputTransform {
 structure QueryOutputTransformInput {
     @required
     sdkOutput: QueryOutput,
+    @required
+    originalInput: QueryInput,
 }
 
 structure QueryOutputTransformOutput {
@@ -236,6 +247,8 @@ operation TransactWriteItemsOutputTransform {
 structure TransactWriteItemsOutputTransformInput {
     @required
     sdkOutput: TransactWriteItemsOutput,
+    @required
+    originalInput: TransactWriteItemsInput,
 }
 
 structure TransactWriteItemsOutputTransformOutput {
@@ -266,6 +279,8 @@ operation UpdateItemOutputTransform {
 structure UpdateItemOutputTransformInput {
     @required
     sdkOutput: UpdateItemOutput,
+    @required
+    originalInput: UpdateItemInput,
 }
 
 structure UpdateItemOutputTransformOutput {
@@ -296,6 +311,8 @@ operation DeleteItemOutputTransform {
 structure DeleteItemOutputTransformInput {
     @required
     sdkOutput: DeleteItemOutput,
+    @required
+    originalInput: DeleteItemInput,
 }
 
 structure DeleteItemOutputTransformOutput {
@@ -326,6 +343,8 @@ operation TransactGetItemsOutputTransform {
 structure TransactGetItemsOutputTransformInput {
     @required
     sdkOutput: TransactGetItemsOutput,
+    @required
+    originalInput: TransactGetItemsInput,
 }
 
 structure TransactGetItemsOutputTransformOutput {
@@ -356,6 +375,8 @@ operation ExecuteStatementOutputTransform {
 structure ExecuteStatementOutputTransformInput {
     @required
     sdkOutput: ExecuteStatementOutput,
+    @required
+    originalInput: ExecuteStatementInput,
 }
 
 structure ExecuteStatementOutputTransformOutput {
@@ -386,6 +407,8 @@ operation BatchExecuteStatementOutputTransform {
 structure BatchExecuteStatementOutputTransformInput {
     @required
     sdkOutput: BatchExecuteStatementOutput,
+    @required
+    originalInput: BatchExecuteStatementInput,
 }
 
 structure BatchExecuteStatementOutputTransformOutput {
@@ -416,6 +439,8 @@ operation ExecuteTransactionOutputTransform {
 structure ExecuteTransactionOutputTransformInput {
     @required
     sdkOutput: ExecuteTransactionOutput,
+    @required
+    originalInput: ExecuteTransactionInput,
 }
 
 structure ExecuteTransactionOutputTransformOutput {

--- a/DynamoDbEncryptionMiddlewareInternal/test/DynamoDbEncryptionMiddlewareInternalTest.dfy
+++ b/DynamoDbEncryptionMiddlewareInternal/test/DynamoDbEncryptionMiddlewareInternalTest.dfy
@@ -41,13 +41,23 @@ module DynamoDbEncryptionMiddlewareInternalTest {
   method {:test} TestGetItemOutputTransform() {
     // Currently it does not matter what our input is
     var middlewareUnderTest := TestFixtures.GetDynamoDbEncryptionMiddlewareInternal();
+    var input := DDB.GetItemInput(
+      TableName := "foo",
+      Key := map[],
+      AttributesToGet := None(),
+      ConsistentRead := None(),
+      ReturnConsumedCapacity := None(),
+      ProjectionExpression := None(),
+      ExpressionAttributeNames := None()
+    );
     var output := DDB.GetItemOutput(
       Item := None(),
       ConsumedCapacity := None()
     );
     var transformed := middlewareUnderTest.GetItemOutputTransform(
       AwsCryptographyDynamoDbEncryptionMiddlewareInternalTypes.GetItemOutputTransformInput(
-        sdkOutput := output
+        sdkOutput := output,
+        originalInput := input
       )
     );
 
@@ -90,9 +100,22 @@ module DynamoDbEncryptionMiddlewareInternalTest {
       ConsumedCapacity := None(),
       ItemCollectionMetrics := None()
     );
+    var input := DDB.PutItemInput(
+      TableName := "foo",
+      Item := map[],
+      Expected := None(),
+      ReturnValues := None(),
+      ReturnConsumedCapacity := None(),
+      ReturnItemCollectionMetrics := None(),
+      ConditionalOperator := None(),
+      ConditionExpression := None(),
+      ExpressionAttributeNames := None(),
+      ExpressionAttributeValues := None()
+    );
     var transformed := middlewareUnderTest.PutItemOutputTransform(
       AwsCryptographyDynamoDbEncryptionMiddlewareInternalTypes.PutItemOutputTransformInput(
-        sdkOutput := output
+        sdkOutput := output,
+        originalInput := input
       )
     );
 
@@ -135,9 +158,22 @@ module DynamoDbEncryptionMiddlewareInternalTest {
       ItemCollectionMetrics := None(),
       ConsumedCapacity := None()
     );
+    var input := DDB.BatchWriteItemInput(
+      RequestItems := map[
+        "foo" := [
+          DDB.WriteRequest (
+            PutRequest := None(),
+            DeleteRequest := None()
+          )
+        ]
+      ],
+      ReturnConsumedCapacity := None(),
+      ReturnItemCollectionMetrics := None()
+    );
     var transformed := middlewareUnderTest.BatchWriteItemOutputTransform(
       AwsCryptographyDynamoDbEncryptionMiddlewareInternalTypes.BatchWriteItemOutputTransformInput(
-        sdkOutput := output
+        sdkOutput := output,
+        originalInput := input
       )
     );
 
@@ -182,9 +218,24 @@ module DynamoDbEncryptionMiddlewareInternalTest {
       UnprocessedKeys := None(),
       ConsumedCapacity := None()
     );
+    var input := DDB.BatchGetItemInput(
+      RequestItems := map[
+        "foo" := DDB.KeysAndAttributes(
+          KeyList := [
+            map[]
+          ],
+          AttributesToGet := None(),
+          ConsistentRead := None(),
+          ProjectionExpression := None(),
+          ExpressionAttributeNames := None()
+        )
+      ],
+      ReturnConsumedCapacity := None()
+    );
     var transformed := middlewareUnderTest.BatchGetItemOutputTransform(
       AwsCryptographyDynamoDbEncryptionMiddlewareInternalTypes.BatchGetItemOutputTransformInput(
-        sdkOutput := output
+        sdkOutput := output,
+        originalInput := input
       )
     );
 
@@ -235,9 +286,28 @@ module DynamoDbEncryptionMiddlewareInternalTest {
       LastEvaluatedKey := None(),
       ConsumedCapacity := None()
     );
+    var input := DDB.ScanInput(
+      TableName := "foo",
+      IndexName := None(),
+      AttributesToGet := None(),
+      Limit := None(),
+      Select := None(),
+      ScanFilter := None(),
+      ConditionalOperator := None(),
+      ExclusiveStartKey := None(),
+      ReturnConsumedCapacity := None(),
+      TotalSegments := None(),
+      Segment := None(),
+      ProjectionExpression := None(),
+      FilterExpression := None(),
+      ExpressionAttributeNames := None(),
+      ExpressionAttributeValues := None(),
+      ConsistentRead := None()
+    );
     var transformed := middlewareUnderTest.ScanOutputTransform(
       AwsCryptographyDynamoDbEncryptionMiddlewareInternalTypes.ScanOutputTransformInput(
-        sdkOutput := output
+        sdkOutput := output,
+        originalInput := input
       )
     );
 
@@ -289,9 +359,29 @@ module DynamoDbEncryptionMiddlewareInternalTest {
       LastEvaluatedKey := None(),
       ConsumedCapacity := None()
     );
+    var input := DDB.QueryInput(
+      TableName := "foo",
+      IndexName := None(),
+      Select := None(),
+      AttributesToGet := None(),
+      Limit := None(),
+      ConsistentRead := None(),
+      KeyConditions := None(),
+      QueryFilter := None(),
+      ConditionalOperator := None(),
+      ScanIndexForward := None(),
+      ExclusiveStartKey := None(),
+      ReturnConsumedCapacity := None(),
+      ProjectionExpression := None(),
+      FilterExpression := None(),
+      KeyConditionExpression := None(),
+      ExpressionAttributeNames := None(),
+      ExpressionAttributeValues := None()
+    );
     var transformed := middlewareUnderTest.QueryOutputTransform(
       AwsCryptographyDynamoDbEncryptionMiddlewareInternalTypes.QueryOutputTransformInput(
-        sdkOutput := output
+        sdkOutput := output,
+        originalInput := input
       )
     );
 
@@ -334,9 +424,23 @@ module DynamoDbEncryptionMiddlewareInternalTest {
       ConsumedCapacity := None(),
       ItemCollectionMetrics := None()
     );
+    var input := DDB.TransactWriteItemsInput(
+      TransactItems := [
+        DDB.TransactWriteItem(
+          ConditionCheck := None(),
+          Put := None(),
+          Delete := None(),
+          Update := None()
+        )
+      ],
+      ReturnConsumedCapacity := None(),
+      ReturnItemCollectionMetrics := None(),
+      ClientRequestToken := None()
+    );
     var transformed := middlewareUnderTest.TransactWriteItemsOutputTransform(
       AwsCryptographyDynamoDbEncryptionMiddlewareInternalTypes.TransactWriteItemsOutputTransformInput(
-        sdkOutput := output
+        sdkOutput := output,
+        originalInput := input
       )
     );
 
@@ -381,9 +485,24 @@ module DynamoDbEncryptionMiddlewareInternalTest {
       ConsumedCapacity := None(),
       ItemCollectionMetrics := None()
     );
+    var input := DDB.UpdateItemInput(
+      TableName := "foo",
+      Key := map[],
+      AttributeUpdates := None(),
+      Expected := None(),
+      ConditionalOperator := None(),
+      ReturnValues := None(),
+      ReturnConsumedCapacity := None(),
+      ReturnItemCollectionMetrics := None(),
+      UpdateExpression := None(),
+      ConditionExpression := None(),
+      ExpressionAttributeNames := None(),
+      ExpressionAttributeValues := None()
+    );
     var transformed := middlewareUnderTest.UpdateItemOutputTransform(
       AwsCryptographyDynamoDbEncryptionMiddlewareInternalTypes.UpdateItemOutputTransformInput(
-        sdkOutput := output
+        sdkOutput := output,
+        originalInput := input
       )
     );
 
@@ -426,9 +545,22 @@ module DynamoDbEncryptionMiddlewareInternalTest {
       ConsumedCapacity := None(),
       ItemCollectionMetrics := None()
     );
+    var input := DDB.DeleteItemInput(
+      TableName := "foo",
+      Key := map[],
+      Expected := None(),
+      ConditionalOperator := None(),
+      ReturnValues := None(),
+      ReturnConsumedCapacity := None(),
+      ReturnItemCollectionMetrics := None(),
+      ConditionExpression := None(),
+      ExpressionAttributeNames := None(),
+      ExpressionAttributeValues := None()
+    );
     var transformed := middlewareUnderTest.DeleteItemOutputTransform(
       AwsCryptographyDynamoDbEncryptionMiddlewareInternalTypes.DeleteItemOutputTransformInput(
-        sdkOutput := output
+        sdkOutput := output,
+        originalInput := input
       )
     );
 
@@ -471,9 +603,23 @@ module DynamoDbEncryptionMiddlewareInternalTest {
       ConsumedCapacity := None(),
       Responses := None()
     );
+    var input := DDB.TransactGetItemsInput(
+      TransactItems := [
+        DDB.TransactGetItem(
+          Get := DDB.Get(
+            Key := map[],
+            TableName := "foo",
+            ProjectionExpression := None(),
+            ExpressionAttributeNames := None()
+          )
+        )
+      ],
+      ReturnConsumedCapacity := None()
+    );
     var transformed := middlewareUnderTest.TransactGetItemsOutputTransform(
       AwsCryptographyDynamoDbEncryptionMiddlewareInternalTypes.TransactGetItemsOutputTransformInput(
-        sdkOutput := output
+        sdkOutput := output,
+        originalInput := input
       )
     );
 
@@ -513,9 +659,18 @@ module DynamoDbEncryptionMiddlewareInternalTest {
       ConsumedCapacity := None(),
       LastEvaluatedKey := None()
     );
+    var input := DDB.ExecuteStatementInput(
+      Statement := "foo",
+      Parameters := None(),
+      ConsistentRead := None(),
+      NextToken := None(),
+      ReturnConsumedCapacity := None(),
+      Limit := None()
+    );
     var transformed := middlewareUnderTest.ExecuteStatementOutputTransform(
       AwsCryptographyDynamoDbEncryptionMiddlewareInternalTypes.ExecuteStatementOutputTransformInput(
-        sdkOutput := output
+        sdkOutput := output,
+        originalInput := input
       )
     );
 
@@ -555,9 +710,20 @@ module DynamoDbEncryptionMiddlewareInternalTest {
       Responses := None(),
       ConsumedCapacity := None()
     );
+    var input := DDB.BatchExecuteStatementInput(
+      Statements := [
+        DDB.BatchStatementRequest(
+          Statement := "foo",
+          Parameters := None(),
+          ConsistentRead := None()
+        )
+      ],
+      ReturnConsumedCapacity := None()
+    );
     var transformed := middlewareUnderTest.BatchExecuteStatementOutputTransform(
       AwsCryptographyDynamoDbEncryptionMiddlewareInternalTypes.BatchExecuteStatementOutputTransformInput(
-        sdkOutput := output
+        sdkOutput := output,
+        originalInput := input
       )
     );
 
@@ -597,9 +763,20 @@ module DynamoDbEncryptionMiddlewareInternalTest {
       Responses := None(),
       ConsumedCapacity := None()
     );
+    var input := DDB.ExecuteTransactionInput(
+      TransactStatements :=  [
+        DDB.ParameterizedStatement (
+          Statement := "foo",
+          Parameters := None()
+        )
+      ],
+      ClientRequestToken := None(),
+      ReturnConsumedCapacity := None()
+    );
     var transformed := middlewareUnderTest.ExecuteTransactionOutputTransform(
       AwsCryptographyDynamoDbEncryptionMiddlewareInternalTypes.ExecuteTransactionOutputTransformInput(
-        sdkOutput := output
+        sdkOutput := output,
+        originalInput := input
       )
     );
 


### PR DESCRIPTION
Add input to middleware interface to allow access to the original input. Each SDK will need a mechanism for passing this information into this interface. For SDKs that have a powerful middleware approach (such as JS), or require wrapping the SDK client, this is trivial. For the Java SDK we may make use of: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/interceptor/ExecutionAttributes.html

This PR adds the new param to the model, generates the smithy->Dafny changes to the Types file, and updates the tests to include this new param.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
