### PR TITLE
fix: Update Item Encryptor builder to take correct Keyring/CMM type

### DIFF
--- a/DynamoDbEncryption/runtimes/java/src/test/java/software/aws/cryptography/dynamoDbEncryption/OtherTests.java
+++ b/DynamoDbEncryption/runtimes/java/src/test/java/software/aws/cryptography/dynamoDbEncryption/OtherTests.java
@@ -5,20 +5,51 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.cryptography.dynamoDbItemEncryptor.DynamoDbItemEncryptor;
+import software.amazon.cryptography.dynamoDbItemEncryptor.model.DynamoDbItemEncryptorConfig;
 import software.amazon.cryptography.materialProviders.Keyring;
 import software.amazon.cryptography.materialProviders.MaterialProviders;
 import software.amazon.cryptography.materialProviders.model.*;
+import software.amazon.cryptography.structuredEncryption.model.CryptoAction;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static com.amazonaws.services.kms.model.EncryptionAlgorithmSpec.RSAES_OAEP_SHA_1;
 import static software.aws.cryptography.dynamoDbEncryption.TestUtils.KMS_TEST_KEY_ID;
+import static software.aws.cryptography.dynamoDbEncryption.TestUtils.createStaticKeyring;
 
 // Here we are testing some manually generated interfaces that don't technically belong to this package,
 // but exist alongside this package as a deliverable, and it is easiest to test them here for now.
 // TODO these should be moved appropriately when they are properly being generated.
 public class OtherTests {
+
+    @Test
+    public void TestItemEncryptorConstruction() {
+        Map<String, CryptoAction> actions = new HashMap<String, CryptoAction>();
+        actions.put("partition_key", CryptoAction.SIGN_ONLY);
+        actions.put("sort_key", CryptoAction.SIGN_ONLY);
+        actions.put("attrA", CryptoAction.ENCRYPT_AND_SIGN);
+        actions.put("attrB", CryptoAction.SIGN_ONLY);
+        actions.put("attrC", CryptoAction.DO_NOTHING);
+
+        DynamoDbItemEncryptor encryptor = DynamoDbItemEncryptor.builder()
+                .DynamoDbItemEncryptorConfig(
+                        DynamoDbItemEncryptorConfig.builder()
+                                .tableName("my-data-table")
+                                .partitionKeyName("partition_key")
+                                .sortKeyName("sort_key")
+                                .keyring(createStaticKeyring())
+                                .attributeActions(actions)
+                                .allowedUnauthenticatedAttributes(Collections.singletonList("attrC"))
+                                .allowedUnauthenticatedAttributePrefix("*")
+                                .build())
+                .build();
+        assertNotNull(encryptor);
+    }
 
     @Test
     public void TestCreateBranchKeyStore() {

--- a/DynamoDbItemEncryptor/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/dynamoDbItemEncryptor/ToDafny.java
+++ b/DynamoDbItemEncryptor/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/dynamoDbItemEncryptor/ToDafny.java
@@ -95,11 +95,11 @@ public class ToDafny {
         : Option.create_None();
     Option<IKeyring> keyring;
     keyring = Objects.nonNull(nativeValue.keyring()) ?
-        Option.create_Some((nativeValue.keyring()))
+        Option.create_Some(software.amazon.cryptography.materialProviders.ToDafny.Keyring(nativeValue.keyring()))
         : Option.create_None();
     Option<ICryptographicMaterialsManager> cmm;
     cmm = Objects.nonNull(nativeValue.cmm()) ?
-        Option.create_Some((nativeValue.cmm()))
+        Option.create_Some(software.amazon.cryptography.materialProviders.ToDafny.CryptographicMaterialsManager(nativeValue.cmm()))
         : Option.create_None();
     return new DynamoDbItemEncryptorConfig(tableName, partitionKeyName, sortKeyName, attributeActions, allowedUnauthenticatedAttributes, allowedUnauthenticatedAttributePrefix, keyring, cmm);
   }

--- a/DynamoDbItemEncryptor/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/dynamoDbItemEncryptor/ToNative.java
+++ b/DynamoDbItemEncryptor/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/dynamoDbItemEncryptor/ToNative.java
@@ -98,10 +98,10 @@ public class ToNative {
       nativeBuilder.allowedUnauthenticatedAttributePrefix(software.amazon.dafny.conversion.ToNative.Simple.String(dafnyValue.dtor_allowedUnauthenticatedAttributePrefix().dtor_value()));
     }
     if (dafnyValue.dtor_keyring().is_Some()) {
-      nativeBuilder.keyring((dafnyValue.dtor_keyring().dtor_value()));
+      nativeBuilder.keyring(software.amazon.cryptography.materialProviders.ToNative.Keyring((dafnyValue.dtor_keyring().dtor_value())));
     }
     if (dafnyValue.dtor_cmm().is_Some()) {
-      nativeBuilder.cmm((dafnyValue.dtor_cmm().dtor_value()));
+      nativeBuilder.cmm(software.amazon.cryptography.materialProviders.ToNative.CryptographicMaterialsManager((dafnyValue.dtor_cmm().dtor_value())));
     }
     return nativeBuilder.build();
   }

--- a/DynamoDbItemEncryptor/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/dynamoDbItemEncryptor/model/DynamoDbItemEncryptorConfig.java
+++ b/DynamoDbItemEncryptor/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/dynamoDbItemEncryptor/model/DynamoDbItemEncryptorConfig.java
@@ -3,11 +3,13 @@
 // Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
 package software.amazon.cryptography.dynamoDbItemEncryptor.model;
 
-import Dafny.Aws.Cryptography.MaterialProviders.Types.ICryptographicMaterialsManager;
-import Dafny.Aws.Cryptography.MaterialProviders.Types.IKeyring;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import software.amazon.cryptography.materialProviders.CryptographicMaterialsManager;
+import software.amazon.cryptography.materialProviders.Keyring;
+import software.amazon.cryptography.materialProviders.ICryptographicMaterialsManager;
+import software.amazon.cryptography.materialProviders.IKeyring;
 import software.amazon.cryptography.structuredEncryption.model.CryptoAction;
 
 public class DynamoDbItemEncryptorConfig {
@@ -23,9 +25,9 @@ public class DynamoDbItemEncryptorConfig {
 
   private final String allowedUnauthenticatedAttributePrefix;
 
-  private final IKeyring keyring;
+  private final Keyring keyring;
 
-  private final ICryptographicMaterialsManager cmm;
+  private final CryptographicMaterialsManager cmm;
 
   protected DynamoDbItemEncryptorConfig(BuilderImpl builder) {
     this.tableName = builder.tableName();
@@ -62,11 +64,11 @@ public class DynamoDbItemEncryptorConfig {
     return this.allowedUnauthenticatedAttributePrefix;
   }
 
-  public IKeyring keyring() {
+  public Keyring keyring() {
     return this.keyring;
   }
 
-  public ICryptographicMaterialsManager cmm() {
+  public CryptographicMaterialsManager cmm() {
     return this.cmm;
   }
 
@@ -103,13 +105,13 @@ public class DynamoDbItemEncryptorConfig {
 
     String allowedUnauthenticatedAttributePrefix();
 
-    Builder keyring(IKeyring keyring);
+    <I extends IKeyring> Builder keyring(I keyring);
 
-    IKeyring keyring();
+    Keyring keyring();
 
-    Builder cmm(ICryptographicMaterialsManager cmm);
+    <I extends ICryptographicMaterialsManager> Builder cmm(I cmm);
 
-    ICryptographicMaterialsManager cmm();
+    CryptographicMaterialsManager cmm();
 
     DynamoDbItemEncryptorConfig build();
   }
@@ -127,9 +129,9 @@ public class DynamoDbItemEncryptorConfig {
 
     protected String allowedUnauthenticatedAttributePrefix;
 
-    protected IKeyring keyring;
+    protected Keyring keyring;
 
-    protected ICryptographicMaterialsManager cmm;
+    protected CryptographicMaterialsManager cmm;
 
     protected BuilderImpl() {
     }
@@ -200,21 +202,21 @@ public class DynamoDbItemEncryptorConfig {
       return this.allowedUnauthenticatedAttributePrefix;
     }
 
-    public Builder keyring(IKeyring keyring) {
-      this.keyring = keyring;
+    public <I extends IKeyring> Builder keyring(I keyring) {
+      this.keyring = Keyring.create(keyring);
       return this;
     }
 
-    public IKeyring keyring() {
+    public Keyring keyring() {
       return this.keyring;
     }
 
-    public Builder cmm(ICryptographicMaterialsManager cmm) {
-      this.cmm = cmm;
+    public <I extends ICryptographicMaterialsManager> Builder cmm(I cmm) {
+      this.cmm = CryptographicMaterialsManager.create(cmm);
       return this;
     }
 
-    public ICryptographicMaterialsManager cmm() {
+    public CryptographicMaterialsManager cmm() {
       return this.cmm;
     }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
