### PR TITLE
chore: repair

### DIFF
--- a/SharedMakefile.mk
+++ b/SharedMakefile.mk
@@ -326,11 +326,11 @@ local_transpile_impl_net_single: OUT=runtimes/net/ImplementationFromDafny
 local_transpile_impl_net_single: local_transpile_impl_single
 
 local_transpile_impl_single: deps_var=SERVICE_DEPS_$(SERVICE)
-local_transpile_impl_single: TRANSPILE_TARGETS=./dafny/$(SERVICE)/src/$(FILE)
+local_transpile_impl_single: TRANSPILE_TARGETS=./dafny/$(SERVICE)/src/Index.dfy
 local_transpile_impl_single: TRANSPILE_DEPENDENCIES= \
 		$(patsubst %, -library:$(PROJECT_ROOT)/%/src/Index.dfy, $($(deps_var))) \
 		$(patsubst %, -library:$(PROJECT_ROOT)/%/src/Index.dfy, $(PROJECT_DEPENDENCIES)) \
-		-library:$(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy \
+		-library:$(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy
 local_transpile_impl_single: transpile_implementation
 
 # Targets to transpile single local service for convenience.
@@ -348,9 +348,9 @@ local_transpile_test_net_single: TARGET=cs
 local_transpile_test_net_single: OUT=runtimes/net/tests/TestsFromDafny
 local_transpile_test_net_single: local_transpile_test_single
 
-local_transpile_impl_single: TRANSPILE_TARGETS=./dafny/$(SERVICE)/test/$(FILE)
-local_transpile_impl_single: TRANSPILE_DEPENDENCIES= \
+local_transpile_test_single: TRANSPILE_TARGETS=./dafny/$(SERVICE)/test/$(FILE)
+local_transpile_test_single: TRANSPILE_DEPENDENCIES= \
 		$(patsubst %, -library:dafny/%/src/Index.dfy, $(PROJECT_SERVICES)) \
 		$(patsubst %, -library:$(PROJECT_ROOT)/%/src/Index.dfy, $(PROJECT_DEPENDENCIES)) \
-		-library:$(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy \
+		-library:$(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy
 local_transpile_test_single: transpile_test


### PR DESCRIPTION
Two lines had an unwanted backslash at the end, which hid the following make target

Two lines say "TRANSPILE_TARGETS=./dafny/$(SERVICE)/test/$(FILE)" where FILE is undefined, leaving the plain directory "./dafny/$(SERVICE)/test/" which is an error.

I think maybe for impl, that should be Index.dfy, for test I have no idea.

At the end of file, two "impl" targets are repeated, which I think should be "test"

