### PR TITLE
fix: Header MakeLegend proof for Dafny 4.0

### DIFF
--- a/DynamoDbEncryption/dafny/StructuredEncryption/src/Header.dfy
+++ b/DynamoDbEncryption/dafny/StructuredEncryption/src/Header.dfy
@@ -356,20 +356,28 @@ module StructuredEncryptionHeader {
       && |ret.value| == CountAuthAttrs(schema.content.SchemaMap)
   {
     var data := schema.content.SchemaMap;
-    var authSchema := map k <- data.Keys | IsAuthAttr(data[k].content.Action) :: k := data[k];
-    assert (map k <- authSchema.Keys | IsAuthAttr(authSchema[k].content.Action) :: k := authSchema[k]) == authSchema;
-    assert CountAuthAttrs(data) == CountAuthAttrs(authSchema);
+    :- Need(forall k <- data :: ValidString(k), E("bad attribute name"));
+
+    var authSchema: map<GoodString, CryptoSchema> := (
+      var rawSchema := RestrictAuthAttrs(data);
+      // Ensure we get the expected number of auth attributes
+      LemmaRestrictAuthAttrsIdempotent(data);
+      assert CountAuthAttrs(data) == |rawSchema|;
+      // Can't use `k as GoodString` for some reason; instead assert validity and let inference handle the rest
+      assert forall k <- rawSchema :: ValidString(k);
+      rawSchema
+    );
     assert CountAuthAttrs(data) == |authSchema|;
+
     //= specification/structured-encryption/header.md#encrypt-legend-bytes
     //# The Encrypt Legend Bytes MUST be serialized as follows:
     // 1. Order every authenticated attribute in the item by the Canonical Path
     // 2. For each authenticated terminal, in order,
     // append one of the byte values specified above to indicate whether
     // that field should be encrypted.
-    :- Need(forall x <- schema.content.SchemaMap.Keys :: ValidString(x), E("bad attribute name"));
     Paths.SimpleCanonUnique(tableName);
 
-    var fn := k => Paths.SimpleCanon(tableName, k);
+    var fn: GoodString -> CanonicalPath := (k: GoodString) => Paths.SimpleCanon(tableName, k);
     assert forall k :: true ==> fn(k) == Paths.SimpleCanon(tableName, k); // This is a bit silly to have to assert, but necessary when SimpleCanon is opaque
 
     MapKeepsCount(authSchema, fn);
@@ -436,8 +444,30 @@ module StructuredEncryptionHeader {
     : nat
     requires forall x <- data.Values :: x.content.Action?
   {
-    |set k <- data.Keys | IsAuthAttr(data[k].content.Action) :: k|
+    |RestrictAuthAttrs(data)|
   }
+
+  /*
+   * Restrict `data` to just the authenticated attributes.
+   */
+  function method RestrictAuthAttrs(data: CryptoSchemaMap)
+    : (authData: CryptoSchemaMap)
+    requires forall x <- data.Values :: x.content.Action?
+    ensures authData.Keys <= data.Keys
+    ensures forall k <- data :: IsAuthAttr(data[k].content.Action) <==> k in authData
+    ensures forall k <- authData :: authData[k] == data[k]
+    ensures forall k <- authData :: IsAuthAttr(authData[k].content.Action)
+  {
+    map k <- data | IsAuthAttr(data[k].content.Action) :: k := data[k]
+  }
+
+  /*
+   * Lemma: RestrictAuthAttrs is idempotent.
+   */
+  lemma LemmaRestrictAuthAttrsIdempotent(data: CryptoSchemaMap)
+    requires forall x <- data.Values :: x.content.Action?
+    ensures var authData := RestrictAuthAttrs(data); authData == RestrictAuthAttrs(authData)
+  {}
 
   // Legend to Bytes
   function method {:opaque} SerializeLegend(x : Legend)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixes Dafny 4 verification failure where previously, running `make verify` in the top level `DynamoDbEncryption` results in the following:

```
Verifying StructuredEncryptionHeader.MakeLegend (well-formedness) ...
  [1.696 s, solver resource count: 3388892, 37 proof obligations]  errors
/Users/ryanemer/aws-dynamodb-encryption-dafny/DynamoDbEncryption/dafny/StructuredEncryption/src/Header.dfy(361,32): Error: assertion might not hold
/Users/ryanemer/aws-dynamodb-encryption-dafny/DynamoDbEncryption/dafny/StructuredEncryption/src/Header.dfy(362,32): Error: assertion might not hold
```

The proof now successfully verifies in 0.778s / 90K RU via `make verify` on my machine, plus a bit  for helper proofs.

```
Verifying StructuredEncryptionHeader.MakeLegend (well-formedness) ...
  [0.778 s, solver resource count: 896070, 30 proof obligations]  verified

...

Verifying StructuredEncryptionHeader.CountAuthAttrs (well-formedness) ...
  [0.136 s, solver resource count: 114858, 2 proof obligations]  verified

Verifying StructuredEncryptionHeader.RestrictAuthAttrs (well-formedness) ...
  [0.152 s, solver resource count: 180926, 13 proof obligations]  verified

Verifying StructuredEncryptionHeader.LemmaRestrictAuthAttrsIdempotent (well-formedness) ...
  [0.150 s, solver resource count: 116086, 2 proof obligations]  verified

Verifying StructuredEncryptionHeader.LemmaRestrictAuthAttrsIdempotent (correctness) ...
  [0.173 s, solver resource count: 138997, 1 proof obligation]  verified
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
