### PR TITLE
fix: Use RPN key expression

### DIFF
--- a/DynamoDbEncryption/dafny/DynamoDbEncryption/src/FilterExpr.dfy
+++ b/DynamoDbEncryption/dafny/DynamoDbEncryption/src/FilterExpr.dfy
@@ -1190,7 +1190,7 @@ module DynamoDBFilterExpr {
           var expr :- BeaconizeParsedExpr(b, parsed, 0, values.UnwrapOr(map[]), names, true);
           var expr1 := ConvertToPrefix(expr.expr);
           var expr2 := ConvertToRpn(expr1);
-          FilterItems(b, expr.expr, ItemList, expr.names, expr.values)
+          FilterItems(b, expr2, ItemList, expr.names, expr.values)
         else
           Success(ItemList);
       if FilterExpression.Some? then


### PR DESCRIPTION
I found that this is needed to properly parse responses from DDB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
