### PR TITLE
chore: Avoid nested chained let expressions in DynamoToStruct

### DIFF
--- a/DynamoDbEncryption/dafny/DynamoDbEncryption/src/DynamoToStruct.dfy
+++ b/DynamoDbEncryption/dafny/DynamoDbEncryption/src/DynamoToStruct.dfy
@@ -199,10 +199,10 @@ module DynamoToStruct {
     :- Need(s.attributes.None?, "attributes must be None");
     :- Need(s.content.Terminal?, "StructuredData to AttributeValue only works on Terminal data");
 
-    var data := s.content.Terminal;
-    :- Need(|data.typeId| == 2, "Type ID must be two bytes");
-    var attrValueAndLength :- BytesToAttr(data.value, data.typeId, false);
-    :- Need(attrValueAndLength.len == |data.value|, "Mismatch between length of encoded data and length of data");
+    var Terminal(s) := s.content;
+    :- Need(|s.typeId| == 2, "Type ID must be two bytes");
+    var attrValueAndLength :- BytesToAttr(s.value, s.typeId, false);
+    :- Need(attrValueAndLength.len == |s.value|, "Mismatch between length of encoded data and length of data");
     Success(attrValueAndLength.val)
   }
 


### PR DESCRIPTION
*Description of changes:*

Avoiding https://github.com/dafny-lang/dafny/issues/3868 in the `DynamoToStruct` module. This is the only module that has caused CI/compilation failures so far.

The work to remove these expressions from other parts of the Dafny code, is tracked here: https://github.com/awslabs/aws-dynamodb-encryption-dafny/issues/118

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
