### PR TITLE
fix(DE-Java): Benerate LocalService reference

### DIFF
--- a/DynamoDbEncryption/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/dynamoDbEncryption/model/BeaconVersion.java
+++ b/DynamoDbEncryption/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/dynamoDbEncryption/model/BeaconVersion.java
@@ -124,7 +124,7 @@ public class BeaconVersion {
     }
 
     public Builder keyStore(KeyStore keyStore) {
-      this.keyStore = new KeyStore(keyStore);
+      this.keyStore = keyStore;
       return this;
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Smithy-Dafny's generated Java does not
generate converters for LocalServices,
and does not reference them correctly
in Builders.

Note: This will need https://github.com/aws/private-aws-encryption-sdk-dafny-staging/pull/168 to work.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
