### PR TITLE
chore: Add nightly builds for all workflows that use Dafny

### DIFF
--- a/.github/workflows/ci_examples_java.yml
+++ b/.github/workflows/ci_examples_java.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+    # Manual trigger for this workflow, either the normal version
+    # or the nightly build that uses the latest Dafny prerelease
+    # (accordingly to the "nightly" parameter).
     inputs:
       nightly:
         description: 'Run the nightly build'
@@ -18,7 +21,7 @@ on:
     # Timing chosen to be adequately after Dafny's own nightly build,
     # but this might need to be tweaked:
     # https://github.com/dafny-lang/dafny/blob/master/.github/workflows/deep-tests.yml#L16
-    - cron: "30 8 * * *"
+    - cron: "30 16 * * *"
 
 jobs:
   testJava:
@@ -86,6 +89,7 @@ jobs:
       - name: Setup Dafny
         uses: dafny-lang/setup-dafny-action@v1.6.1
         with:
+          # A && B || C is the closest thing to an if .. then ... else ... or ?: expression the GitHub Actions syntax supports.
           dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || "nightly-2023-04-12-f4836e9" }}
 
       - name: Build and locally deploy dependencies for examples

--- a/.github/workflows/ci_test_java.yml
+++ b/.github/workflows/ci_test_java.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+    # Manual trigger for this workflow, either the normal version
+    # or the nightly build that uses the latest Dafny prerelease
+    # (accordingly to the "nightly" parameter).
     inputs:
       nightly:
         description: 'Run the nightly build'
@@ -18,7 +21,7 @@ on:
     # Timing chosen to be adequately after Dafny's own nightly build,
     # but this might need to be tweaked:
     # https://github.com/dafny-lang/dafny/blob/master/.github/workflows/deep-tests.yml#L16
-    - cron: "30 8 * * *"
+    - cron: "30 16 * * *"
 
 jobs:
   testJava:
@@ -82,6 +85,7 @@ jobs:
       - name: Setup Dafny
         uses: dafny-lang/setup-dafny-action@v1.6.1
         with:
+          # A && B || C is the closest thing to an if .. then ... else ... or ?: expression the GitHub Actions syntax supports.
           dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || "nightly-2023-04-12-f4836e9" }}
 
       - name: Setup Java ${{ matrix.java-version }}

--- a/.github/workflows/ci_test_net.yml
+++ b/.github/workflows/ci_test_net.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+    # Manual trigger for this workflow, either the normal version
+    # or the nightly build that uses the latest Dafny prerelease
+    # (accordingly to the "nightly" parameter).
     inputs:
       nightly:
         description: 'Run the nightly build'
@@ -18,7 +21,7 @@ on:
     # Timing chosen to be adequately after Dafny's own nightly build,
     # but this might need to be tweaked:
     # https://github.com/dafny-lang/dafny/blob/master/.github/workflows/deep-tests.yml#L16
-    - cron: "30 8 * * *"
+    - cron: "30 16 * * *"
 
 jobs:
   testDotNet:
@@ -67,6 +70,7 @@ jobs:
       - name: Setup Dafny
         uses: dafny-lang/setup-dafny-action@v1.6.1
         with:
+          # A && B || C is the closest thing to an if .. then ... else ... or ?: expression the GitHub Actions syntax supports.
           dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || "nightly-2023-04-12-f4836e9" }}
 
       - name: Download Dependencies 

--- a/.github/workflows/ci_verification.yml
+++ b/.github/workflows/ci_verification.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+    # Manual trigger for this workflow, either the normal version
+    # or the nightly build that uses the latest Dafny prerelease
+    # (accordingly to the "nightly" parameter).
     inputs:
       nightly:
         description: 'Run the nightly build'
@@ -18,7 +21,7 @@ on:
     # Timing chosen to be adequately after Dafny's own nightly build,
     # but this might need to be tweaked:
     # https://github.com/dafny-lang/dafny/blob/master/.github/workflows/deep-tests.yml#L16
-    - cron: "30 8 * * *"
+    - cron: "30 16 * * *"
 
 jobs:
   verification:
@@ -57,6 +60,7 @@ jobs:
       - name: Setup Dafny
         uses: dafny-lang/setup-dafny-action@v1.6.1
         with:
+          # A && B || C is the closest thing to an if .. then ... else ... or ?: expression the GitHub Actions syntax supports.
           dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || "nightly-2023-04-12-f4836e9" }}
 
       - name: Verify ${{ matrix.library }} Dafny code


### PR DESCRIPTION
*Description of changes:*

Triggers a nightly run of all relevant workflows against the latest nightly prerelease of Dafny. This is our recommended mechanism for early warning for regressions on unreleased changes to Dafny, especially related to verification variability. We've set up the same mechanism on https://github.com/dafny-lang/dafny-reportgenerator and https://github.com/dafny-lang/libraries (although the former is the tidier version - the latter is testing too many version for no benefit and needs cleaning up).

We'll want some mechanism to be alerts when these fail. `dafny-lang/dafny` has every PR check the latest nightly build so that failures are obvious as long as folks are continuing to open PRs, but in that case the nightly build is a blocker since it includes must-run tests before releases, whereas here it would only be informational.

Working on dry run testing on my fork (which will involve some subterfuge to trigger the workflow manually).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
