### PR TITLE
feat: no FNSCB with same name as encrypted field

### DIFF
--- a/DynamoDbEncryption/dafny/DynamoDbEncryption/src/CompoundBeacon.dfy
+++ b/DynamoDbEncryption/dafny/DynamoDbEncryption/src/CompoundBeacon.dfy
@@ -159,7 +159,7 @@ module CompoundBeacon {
     }
 
     predicate method isEncrypted() {
-      Any((p : BeaconPart) => p.Sensitive?, parts)
+      numNonSensitive < |parts|
     }
 
     function method {:tailrecursion} getPartFromPrefix(value : string)


### PR DESCRIPTION
Unlike all other beacons, a fully non-sensitive compound beacon must not have the same name as an encrypted field.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
