### PR TITLE
fix(TextVectors-Java): runTests depends on DDB

### DIFF
--- a/TestVectors/runtimes/java/build.gradle.kts
+++ b/TestVectors/runtimes/java/build.gradle.kts
@@ -28,6 +28,10 @@ java {
     }
 }
 
+tasks.withType<JavaCompile>() {
+    options.encoding = "UTF-8"
+}
+
 var caUrl: URI? = null
 @Nullable
 val caUrlStr: String? = System.getenv("CODEARTIFACT_URL_JAVA_CONVERSION")
@@ -102,55 +106,6 @@ publishing {
     repositories { mavenLocal() }
 }
 
-tasks.withType<JavaCompile>() {
-    options.encoding = "UTF-8"
-}
-
-tasks.test {
-    useTestNG()
-    dependsOn("CopyDynamoDb")
-    systemProperty("java.library.path", "build/libs")
-
-    // This will show System.out.println statements
-    testLogging.showStandardStreams = true
-
-    testLogging {
-        lifecycle {
-            events = mutableSetOf(TestLogEvent.FAILED, TestLogEvent.PASSED, TestLogEvent.SKIPPED)
-            exceptionFormat = TestExceptionFormat.FULL
-            showExceptions = true
-            showCauses = true
-            showStackTraces = true
-            showStandardStreams = true
-        }
-        info.events = lifecycle.events
-        info.exceptionFormat = lifecycle.exceptionFormat
-    }
-
-    // See https://github.com/gradle/kotlin-dsl/issues/836
-    addTestListener(object : TestListener {
-        override fun beforeSuite(suite: TestDescriptor) {}
-        override fun beforeTest(testDescriptor: TestDescriptor) {}
-        override fun afterTest(testDescriptor: TestDescriptor, result: TestResult) {}
-
-        override fun afterSuite(suite: TestDescriptor, result: TestResult) {
-            if (suite.parent == null) { // root suite
-                logger.lifecycle("----")
-                logger.lifecycle("Test result: ${result.resultType}")
-                logger.lifecycle("Test summary: ${result.testCount} tests, " +
-                        "${result.successfulTestCount} succeeded, " +
-                        "${result.failedTestCount} failed, " +
-                        "${result.skippedTestCount} skipped")
-            }
-        }
-    })
-}
-
-tasks.register<JavaExec>("runTests") {
-    dependsOn("copyKeysJSON")
-    mainClass.set("TestsFromDafny")
-    classpath = sourceSets["test"].runtimeClasspath
-}
 
 tasks.register<Copy>("copyKeysJSON") {
     from(layout.projectDirectory.file("../../../submodules/MaterialProviders/TestVectorsAwsCryptographicMaterialProviders/dafny/TestVectorsAwsCryptographicMaterialProviders/test/keys.json"))
@@ -164,4 +119,12 @@ tasks.register<Copy>("CopyDynamoDb")  {
         include("*.so")
     }
     into("build/libs")
+}
+
+tasks.register<JavaExec>("runTests") {
+    dependsOn("CopyDynamoDb")    
+    dependsOn("copyKeysJSON")
+    systemProperty("java.library.path", "build/libs")    
+    mainClass.set("TestsFromDafny")
+    classpath = sourceSets["test"].runtimeClasspath
 }


### PR DESCRIPTION
*Issue #, if available:*
@seebees I am told you are tacking of over this, 
but I was working on this for a hot second and I think this change will help.

*Description of changes:*
There are no unit tests for TestNG to discover, so the `test` task is not needed.
However, the `runTests` task needs all the local DDB configuration that was added.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
