### PR TITLE
fix(EnhancedClient): Correctly Identify Index attributes

### DIFF
--- a/DynamoDbEncryption/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/enhancedclient/DynamoDbEnhancedClientEncryption.java
+++ b/DynamoDbEncryption/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/enhancedclient/DynamoDbEnhancedClientEncryption.java
@@ -1,13 +1,17 @@
 package software.amazon.cryptography.dbencryptionsdk.dynamodb.enhancedclient;
 
+import java.util.*;
+import java.util.stream.Collectors;
+
+import software.amazon.awssdk.enhanced.dynamodb.IndexMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.KeyAttributeMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
+
 import software.amazon.cryptography.dbencryptionsdk.dynamodb.model.DynamoDbTablesEncryptionConfig;
 import software.amazon.cryptography.dbencryptionsdk.dynamodb.model.DynamoDbEncryptionException;
 import software.amazon.cryptography.dbencryptionsdk.dynamodb.model.DynamoDbTableEncryptionConfig;
 import software.amazon.cryptography.dbencryptionsdk.structuredencryption.model.CryptoAction;
 import software.amazon.cryptography.dbencryptionsdk.dynamodb.DynamoDbEncryptionInterceptor;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 import static software.amazon.cryptography.dbencryptionsdk.dynamodb.enhancedclient.DoNothingTag.CUSTOM_DDB_ENCRYPTION_DO_NOTHING_PREFIX;
 import static software.amazon.cryptography.dbencryptionsdk.dynamodb.enhancedclient.SignOnlyTag.CUSTOM_DDB_ENCRYPTION_SIGN_ONLY_PREFIX;
@@ -27,12 +31,33 @@ public class DynamoDbEnhancedClientEncryption {
                 .build();
     }
 
+    private static Set<String> attributeNamesUsedInIndices(
+        final TableMetadata tableMetadata
+    ) {
+        Set<String> partitionAttributeNames = tableMetadata.indices().stream()
+            .map(IndexMetadata::partitionKey)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .map(KeyAttributeMetadata::name)
+            .collect(Collectors.toSet());
+        Set<String> sortAttributeNames = tableMetadata.indices().stream()
+            .map(IndexMetadata::sortKey)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .map(KeyAttributeMetadata::name)
+            .collect(Collectors.toSet());
+        Set<String> allIndexAttributes = new HashSet<>();
+        allIndexAttributes.addAll(partitionAttributeNames);
+        allIndexAttributes.addAll(sortAttributeNames);
+        return allIndexAttributes;
+    }
+
     private static DynamoDbTableEncryptionConfig getTableConfig(DynamoDbEnhancedTableEncryptionConfig configWithSchema) {
         Map<String, CryptoAction> actions = new HashMap<>();
 
         Set<String> signOnlyAttributes = configWithSchema.schemaOnEncrypt().tableMetadata().customMetadataObject(CUSTOM_DDB_ENCRYPTION_SIGN_ONLY_PREFIX, Set.class).orElseGet(HashSet::new);
         Set<String> doNothingAttributes = configWithSchema.schemaOnEncrypt().tableMetadata().customMetadataObject(CUSTOM_DDB_ENCRYPTION_DO_NOTHING_PREFIX, Set.class).orElseGet(HashSet::new);
-        Set<String> keyAttributes = configWithSchema.schemaOnEncrypt().tableMetadata().keyAttributes().stream().map(val -> val.name()).collect(Collectors.toSet());
+        Set<String> keyAttributes = attributeNamesUsedInIndices(configWithSchema.schemaOnEncrypt().tableMetadata());
 
         if (!Collections.disjoint(keyAttributes, doNothingAttributes)) {
             throw DynamoDbEncryptionException.builder()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`TableSchema`'s store Index information in `indices`, NOT `keyAttributes`.
`keyAttributes` includes Index information, 
but also includes other information about non-Index related attributes.

For example, the Enhanced Client's `AutoGeneratedTimestampRecordExtension` persists 
non-index information in `keyAttributes`.

Furthermore, the Java Doc for `keyAttributes` reads:
> Returns metadata about all the known 'key' attributes for this table, such as primary and secondary index keys, **or any other attribute that forms part of the structure of the table**.

While `indices` reads:
> Returns metadata about all the known indices for this table.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
