### PR TITLE
chore: Add matrix value back since the whole job is disabled now

### DIFF
--- a/.github/workflows/ci_test_net.yml
+++ b/.github/workflows/ci_test_net.yml
@@ -31,8 +31,7 @@ jobs:
     strategy:
       matrix:
         library: [
-          # Reintroduce once MPL builds with .NET
-          # DynamoDbEncryption,
+          DynamoDbEncryption,
         ]
         dotnet-version: [ '6.0.x' ]
         os: [


### PR DESCRIPTION
Fixes nightly build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
