### PR TITLE
fix: Fix overperscriptive test for KmsException

### DIFF
--- a/DynamoDbEncryption/runtimes/java/src/test/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/enhancedclient/DynamoDbEncryptionEnhancedClientIntegrationTests.java
+++ b/DynamoDbEncryption/runtimes/java/src/test/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/enhancedclient/DynamoDbEncryptionEnhancedClientIntegrationTests.java
@@ -341,7 +341,7 @@ public class DynamoDbEncryptionEnhancedClientIntegrationTests {
     }
 
     @Test(
-            expectedExceptions = KmsException.class
+            expectedExceptions = KmsException.class,
             expectedExceptionsMessageRegExp = ".*"
     )
     public void TestKmsError() {

--- a/DynamoDbEncryption/runtimes/java/src/test/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/enhancedclient/DynamoDbEncryptionEnhancedClientIntegrationTests.java
+++ b/DynamoDbEncryption/runtimes/java/src/test/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/enhancedclient/DynamoDbEncryptionEnhancedClientIntegrationTests.java
@@ -342,7 +342,6 @@ public class DynamoDbEncryptionEnhancedClientIntegrationTests {
 
     @Test(
             expectedExceptions = KmsException.class,
-            expectedExceptionsMessageRegExp = "Service returned error code AccessDeniedException.*"
     )
     public void TestKmsError() {
         // Use an KMS Key that does not exist

--- a/DynamoDbEncryption/runtimes/java/src/test/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/enhancedclient/DynamoDbEncryptionEnhancedClientIntegrationTests.java
+++ b/DynamoDbEncryption/runtimes/java/src/test/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/enhancedclient/DynamoDbEncryptionEnhancedClientIntegrationTests.java
@@ -341,7 +341,8 @@ public class DynamoDbEncryptionEnhancedClientIntegrationTests {
     }
 
     @Test(
-            expectedExceptions = KmsException.class,
+            expectedExceptions = KmsException.class
+            expectedExceptionsMessageRegExp = ".*"
     )
     public void TestKmsError() {
         // Use an KMS Key that does not exist


### PR DESCRIPTION
Updating a test to be less restrictive about the expected error from KMS. The purpose of the test is to ensure that we are receiving an SDK-like exception type, not that we always get back a very specific KMS exception back. This update makes the test less brittle and susceptible to changes in the environment running the test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
