### PR TITLE
chore: Always test/build with locally built MPL and add release safeg…

### DIFF
--- a/.github/workflows/ci_test_java.yml
+++ b/.github/workflows/ci_test_java.yml
@@ -78,8 +78,4 @@ jobs:
       - name: Test ${{ matrix.library }}
         working-directory: ./${{ matrix.library }}
         run: |
-          # Clear MPL from cache
-          # We have to do this because MakeFile does not do this yet. The MakeFile automatically builds and deploys dependencies
-          # instead it should be picking it up from Maven.
-          rm -rf ~/.m2/repository/software/amazon/cryptography/aws-cryptographic-material-providers
           make test_java

--- a/.github/workflows/ci_test_vector_java.yml
+++ b/.github/workflows/ci_test_vector_java.yml
@@ -60,8 +60,4 @@ jobs:
       - name: Test TestVectors
         working-directory: ./TestVectors
         run: |
-          # Clear MPL from cache
-          # We have to do this because MakeFile does not do this yet. The MakeFile automatically builds and deploys dependencies
-          # instead it should be picking it up from Maven.
-          rm -rf ~/.m2/repository/software/amazon/cryptography/aws-cryptographic-material-providers
           make test_java

--- a/DynamoDbEncryption/runtimes/java/build.gradle.kts
+++ b/DynamoDbEncryption/runtimes/java/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
 import java.net.URI
 import javax.annotation.Nullable
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
@@ -11,9 +14,17 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
 }
 
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../../project.properties")))
+}
+
 group = "software.amazon.cryptography"
-version = "3.1.0"
+version = props.getProperty("projectJavaVersion")
 description = "Aws Database Encryption Sdk for DynamoDb Java"
+
+var mplVersion = props.getProperty("mplDependencyJavaVersion")
+var dafnyRuntimeJavaVersion = props.getProperty("dafnyRuntimeJavaVersion")
+var smithyDafnyJavaConversionVersion = props.getProperty("smithyDafnyJavaConversionVersion")
 
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(8))
@@ -68,9 +79,9 @@ repositories {
 val dynamodb by configurations.creating
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
-    implementation("software.amazon.smithy.dafny:conversion:0.1")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.0.0")
+    implementation("org.dafny:DafnyRuntime:${dafnyRuntimeJavaVersion}")
+    implementation("software.amazon.smithy.dafny:conversion:${smithyDafnyJavaConversionVersion}")
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${mplVersion}")
 
     implementation(platform("software.amazon.awssdk:bom:2.20.128"))
     implementation("software.amazon.awssdk:dynamodb")

--- a/Examples/runtimes/java/DynamoDbEncryption/build.gradle.kts
+++ b/Examples/runtimes/java/DynamoDbEncryption/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 var props = Properties().apply {
-    load(FileInputStream(File(rootProject.rootDir, "../../../project.properties")))
+    load(FileInputStream(File(rootProject.rootDir, "../../../../project.properties")))
 }
 
 group = "software.amazon.cryptography"

--- a/Examples/runtimes/java/DynamoDbEncryption/build.gradle.kts
+++ b/Examples/runtimes/java/DynamoDbEncryption/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
 import java.net.URI
 import javax.annotation.Nullable
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
@@ -9,9 +12,16 @@ plugins {
     id("io.freefair.lombok") version "8.1.0"
 }
 
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../../project.properties")))
+}
+
 group = "software.amazon.cryptography"
 version = "1.0-SNAPSHOT"
 description = "DynamoDbEncryptionExamples"
+
+var mplVersion = props.getProperty("mplDependencyJavaVersion")
+var ddbecVersion = props.getProperty("projectJavaVersion")
 
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(8))
@@ -57,8 +67,8 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.cryptography:aws-database-encryption-sdk-dynamodb:3.1.0")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.0.0")
+    implementation("software.amazon.cryptography:aws-database-encryption-sdk-dynamodb:${ddbecVersion}")
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${mplVersion}")
 
     implementation(platform("software.amazon.awssdk:bom:2.19.1"))
     implementation("software.amazon.awssdk:arns")

--- a/Examples/runtimes/java/Migration/DDBECToAWSDBE/build.gradle.kts
+++ b/Examples/runtimes/java/Migration/DDBECToAWSDBE/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 var props = Properties().apply {
-    load(FileInputStream(File(rootProject.rootDir, "../../../project.properties")))
+    load(FileInputStream(File(rootProject.rootDir, "../../../../../project.properties")))
 }
 
 group = "software.amazon.cryptography"

--- a/Examples/runtimes/java/Migration/DDBECToAWSDBE/build.gradle.kts
+++ b/Examples/runtimes/java/Migration/DDBECToAWSDBE/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
 import java.net.URI
 import javax.annotation.Nullable
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
@@ -8,9 +11,16 @@ plugins {
     `java-library`
 }
 
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../../project.properties")))
+}
+
 group = "software.amazon.cryptography"
 version = "1.0-SNAPSHOT"
 description = "AWSDatabaseEncryptionSDKMigrationExamples"
+
+var mplVersion = props.getProperty("mplDependencyJavaVersion")
+var ddbecVersion = props.getProperty("projectJavaVersion")
 
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(8))
@@ -56,8 +66,8 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.cryptography:aws-database-encryption-sdk-dynamodb:3.1.0")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.0.0")
+    implementation("software.amazon.cryptography:aws-database-encryption-sdk-dynamodb:${ddbecVersion}")
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${mplVersion}")
 
     implementation(platform("software.amazon.awssdk:bom:2.19.1"))
     implementation("software.amazon.awssdk:dynamodb")

--- a/Examples/runtimes/java/Migration/PlaintextToAWSDBE/build.gradle.kts
+++ b/Examples/runtimes/java/Migration/PlaintextToAWSDBE/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 var props = Properties().apply {
-    load(FileInputStream(File(rootProject.rootDir, "../../../project.properties")))
+    load(FileInputStream(File(rootProject.rootDir, "../../../../../project.properties")))
 }
 
 group = "software.amazon.cryptography"

--- a/Examples/runtimes/java/Migration/PlaintextToAWSDBE/build.gradle.kts
+++ b/Examples/runtimes/java/Migration/PlaintextToAWSDBE/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
 import java.net.URI
 import javax.annotation.Nullable
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
@@ -8,9 +11,16 @@ plugins {
     `java-library`
 }
 
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../../project.properties")))
+}
+
 group = "software.amazon.cryptography"
 version = "1.0-SNAPSHOT"
 description = "AWSDatabaseEncryptionSDKMigrationExamples"
+
+var mplVersion = props.getProperty("mplDependencyJavaVersion")
+var ddbecVersion = props.getProperty("projectJavaVersion")
 
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(8))
@@ -56,8 +66,8 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.cryptography:aws-database-encryption-sdk-dynamodb:3.1.0")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.0.0")
+    implementation("software.amazon.cryptography:aws-database-encryption-sdk-dynamodb:${ddbecVersion}")
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${mplVersion}")
 
     implementation(platform("software.amazon.awssdk:bom:2.19.1"))
     implementation("software.amazon.awssdk:dynamodb")

--- a/TestVectors/runtimes/java/build.gradle.kts
+++ b/TestVectors/runtimes/java/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
 import java.net.URI
 import javax.annotation.Nullable
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
@@ -11,6 +14,15 @@ plugins {
     `java-library`
     `maven-publish`
 }
+
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../../project.properties")))
+}
+
+var mplVersion = props.getProperty("mplDependencyJavaVersion")
+var ddbecVersion = props.getProperty("projectJavaVersion")
+var dafnyRuntimeJavaVersion = props.getProperty("dafnyRuntimeJavaVersion")
+var smithyDafnyJavaConversionVersion = props.getProperty("smithyDafnyJavaConversionVersion")
 
 group = "software.amazon.cryptography"
 version = "1.0-SNAPSHOT"
@@ -70,10 +82,10 @@ repositories {
 val dynamodb by configurations.creating
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
-    implementation("software.amazon.smithy.dafny:conversion:0.1")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.0.0")
-    implementation("software.amazon.cryptography:aws-database-encryption-sdk-dynamodb:3.1.0")
+    implementation("org.dafny:DafnyRuntime:${dafnyRuntimeJavaVersion}")
+    implementation("software.amazon.smithy.dafny:conversion:${smithyDafnyJavaConversionVersion}")
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${mplVersion}")
+    implementation("software.amazon.cryptography:aws-database-encryption-sdk-dynamodb:${ddbecVersion}")
     implementation("software.amazon.cryptography:TestAwsCryptographicMaterialProviders:1.0-SNAPSHOT")
 
     implementation(platform("software.amazon.awssdk:bom:2.20.138"))

--- a/codebuild/release/release.yml
+++ b/codebuild/release/release.yml
@@ -61,32 +61,32 @@ batch:
   ## The following steps are expected to fail; since maven central takes time to
   ## update its index. For now, a manual download of the jar is needed to assert artifacts are
   ## available. For more information, consult the MCM used for this release.
-  - identifier: validate_release_corretto8
-    depend-on:
-        - upload_to_sonatype
-    buildspec: codebuild/release/validate-release.yml
-    env:
-      variables:
-        JAVA_ENV_VERSION: corretto8
-        JAVA_NUMERIC_VERSION: 8
-      image: aws/codebuild/standard:5.0
+  # - identifier: validate_release_corretto8
+  #   depend-on:
+  #       - upload_to_sonatype
+  #   buildspec: codebuild/release/validate-release.yml
+  #   env:
+  #     variables:
+  #       JAVA_ENV_VERSION: corretto8
+  #       JAVA_NUMERIC_VERSION: 8
+  #     image: aws/codebuild/standard:5.0
 
-  - identifier: validate_release_corretto11
-    depend-on:
-        - upload_to_sonatype
-    buildspec: codebuild/release/validate-release.yml
-    env:
-      variables:
-        JAVA_ENV_VERSION: corretto11
-        JAVA_NUMERIC_VERSION: 11
-      image: aws/codebuild/standard:5.0
+  # - identifier: validate_release_corretto11
+  #   depend-on:
+  #       - upload_to_sonatype
+  #   buildspec: codebuild/release/validate-release.yml
+  #   env:
+  #     variables:
+  #       JAVA_ENV_VERSION: corretto11
+  #       JAVA_NUMERIC_VERSION: 11
+  #     image: aws/codebuild/standard:5.0
   
-  - identifier: validate_release_corretto17
-    depend-on:
-        - upload_to_sonatype
-    buildspec: codebuild/release/validate-release.yml
-    env:
-      variables:
-        JAVA_ENV_VERSION: corretto17
-        JAVA_NUMERIC_VERSION: 17
-      image: aws/codebuild/standard:7.0
+  # - identifier: validate_release_corretto17
+  #   depend-on:
+  #       - upload_to_sonatype
+  #   buildspec: codebuild/release/validate-release.yml
+  #   env:
+  #     variables:
+  #       JAVA_ENV_VERSION: corretto17
+  #       JAVA_NUMERIC_VERSION: 17
+  #     image: aws/codebuild/standard:7.0

--- a/codebuild/release/release.yml
+++ b/codebuild/release/release.yml
@@ -61,32 +61,32 @@ batch:
   ## The following steps are expected to fail; since maven central takes time to
   ## update its index. For now, a manual download of the jar is needed to assert artifacts are
   ## available. For more information, consult the MCM used for this release.
-  # - identifier: validate_release_corretto8
-  #   depend-on:
-  #       - upload_to_sonatype
-  #   buildspec: codebuild/release/validate-release.yml
-  #   env:
-  #     variables:
-  #       JAVA_ENV_VERSION: corretto8
-  #       JAVA_NUMERIC_VERSION: 8
-  #     image: aws/codebuild/standard:5.0
+  - identifier: validate_release_corretto8
+    depend-on:
+        - upload_to_sonatype
+    buildspec: codebuild/release/validate-release.yml
+    env:
+      variables:
+        JAVA_ENV_VERSION: corretto8
+        JAVA_NUMERIC_VERSION: 8
+      image: aws/codebuild/standard:5.0
 
-  # - identifier: validate_release_corretto11
-  #   depend-on:
-  #       - upload_to_sonatype
-  #   buildspec: codebuild/release/validate-release.yml
-  #   env:
-  #     variables:
-  #       JAVA_ENV_VERSION: corretto11
-  #       JAVA_NUMERIC_VERSION: 11
-  #     image: aws/codebuild/standard:5.0
+  - identifier: validate_release_corretto11
+    depend-on:
+        - upload_to_sonatype
+    buildspec: codebuild/release/validate-release.yml
+    env:
+      variables:
+        JAVA_ENV_VERSION: corretto11
+        JAVA_NUMERIC_VERSION: 11
+      image: aws/codebuild/standard:5.0
   
-  # - identifier: validate_release_corretto17
-  #   depend-on:
-  #       - upload_to_sonatype
-  #   buildspec: codebuild/release/validate-release.yml
-  #   env:
-  #     variables:
-  #       JAVA_ENV_VERSION: corretto17
-  #       JAVA_NUMERIC_VERSION: 17
-  #     image: aws/codebuild/standard:7.0
+  - identifier: validate_release_corretto17
+    depend-on:
+        - upload_to_sonatype
+    buildspec: codebuild/release/validate-release.yml
+    env:
+      variables:
+        JAVA_ENV_VERSION: corretto17
+        JAVA_NUMERIC_VERSION: 17
+      image: aws/codebuild/standard:7.0

--- a/codebuild/staging/release-staging.yml
+++ b/codebuild/staging/release-staging.yml
@@ -47,8 +47,10 @@ phases:
       - aws sts get-caller-identity
   build:
     commands:
-      - cd DynamoDbEncryption/
+      # Validate the MPL submodule points to the correct release
+      - scripts/validate-mpl-submodule.sh
       # Build and deploy to maven local
+      - cd DynamoDbEncryption/
       - make transpile_implementation_java
       - make transpile_test_java
       - make mvn_local_deploy

--- a/project.properties
+++ b/project.properties
@@ -1,0 +1,4 @@
+projectJavaVersion=3.1.0
+mplDependencyJavaVersion=1.0.0
+dafnyRuntimeJavaVersion=4.1.0
+smithyDafnyJavaConversionVersion=0.1

--- a/project.properties
+++ b/project.properties
@@ -1,4 +1,4 @@
-projectJavaVersion=3.1.0-SNAPSHOT
+projectJavaVersion=3.1.0
 mplDependencyJavaVersion=1.0.0
 dafnyRuntimeJavaVersion=4.1.0
 smithyDafnyJavaConversionVersion=0.1

--- a/project.properties
+++ b/project.properties
@@ -1,4 +1,4 @@
-projectJavaVersion=3.1.0
+projectJavaVersion=3.1.0-SNAPSHOT
 mplDependencyJavaVersion=1.0.0
 dafnyRuntimeJavaVersion=4.1.0
 smithyDafnyJavaConversionVersion=0.1

--- a/scripts/validate-mpl-submodule.sh
+++ b/scripts/validate-mpl-submodule.sh
@@ -15,8 +15,8 @@ if [ "$MPL_SUBMODULE_VERSION" == "" ]; then
   exit 1;
 fi
 
-# Validate this version matches the version used in the DB-ESDK's gradle.properties
+# Validate this version matches the version used in the DB-ESDK's build.gradle
 if [ "$DBESDK_MPL_VERSION" != "$MPL_SUBMODULE_VERSION" ]; then
-  echo "Invalid MaterialProviders submodule. Mismatch between the submodule version ("$MPL_SUBMODULE_VERSION") and the version configured in the DB-ESDK's gradle.properties ("$DBESDK_MPL_VERSION").";
+  echo "Invalid MaterialProviders submodule. Mismatch between the submodule version ("$MPL_SUBMODULE_VERSION") and the version of the configured dependency in project.properties ("$DBESDK_MPL_VERSION").";
   exit 1;
 fi

--- a/scripts/validate-mpl-submodule.sh
+++ b/scripts/validate-mpl-submodule.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# A tiny script to verify that the MPL submodule points to a valid release,
+# and that this release matches the MPL dependency defined in this repo's gradle projects.
+# Run this script from the root of the repo.
+
+# Get the MPL version used in DB-ESDK's build.gradle
+DBESDK_MPL_VERSION=$(cat project.properties | grep "mplDependencyJavaVersion" | sed 's/^.*=//')
+
+# Get version from tag of HEAD in MaterialProviders submodule
+cd submodules/MaterialProviders
+MPL_SUBMODULE_VERSION=$(git tag --points-at HEAD | sed 's/v//');
+if [ "$MPL_SUBMODULE_VERSION" == "" ]; then
+  echo "Invalid MaterialProviders submodule. The submodule must be set to a commit that is tagged as a release.";
+  exit 1;
+fi
+
+# Validate this version matches the version used in the DB-ESDK's gradle.properties
+if [ "$DBESDK_MPL_VERSION" != "$MPL_SUBMODULE_VERSION" ]; then
+  echo "Invalid MaterialProviders submodule. Mismatch between the submodule version ("$MPL_SUBMODULE_VERSION") and the version configured in the DB-ESDK's gradle.properties ("$DBESDK_MPL_VERSION").";
+  exit 1;
+fi


### PR DESCRIPTION
…uards

Updates CI to build/test using local MPL, making it easier to reason about local development, and unblock development with pre-release MPL features.

We already ensure in our release process that we test the examples and test vectors against MPL in maven local, but this PR adds an additional script to ensure there is consistency between the MPL submodule and the MPL version in our build.gradle that can be used before and during a release. It isn't checked in CI, in order to support development against pre-release MPL.

Updated the build.gradle to use the same versions of MPL/Dafnyruntime/etc. across the DB-ESDK, examples, and test vectors. These versions are currently defined in a top level `properties` file, that each individual gradle project reads from. This is Java specific for now, to give us the best bang for our buck today.

Once effect of this is that I think these dependencies will no longer be caught by dependabot. This is probably ok, as we want to be mindful when upgrading these dependencies anyway.

Tested the Codebuild script update on commits [94fc4b4](https://github.com/aws/aws-database-encryption-sdk-dynamodb-java/pull/422/commits/94fc4b46b6b66ab1c1e0c544ce40d4722d92e664), [79926a4](https://github.com/aws/aws-database-encryption-sdk-dynamodb-java/pull/422/commits/79926a404ed9b10ceb76ef19c05f130f59022019), and [e219262](https://github.com/aws/aws-database-encryption-sdk-dynamodb-java/pull/422/commits/e219262b439b6f0692c5bd56db9ab5396d1437c4) to ensure expected success/failures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
