### PR TITLE
chore: update Dafny from 4.1 to 4.2

### DIFF
--- a/.github/workflows/ci_examples_java.yml
+++ b/.github/workflows/ci_examples_java.yml
@@ -63,7 +63,7 @@ jobs:
         uses: dafny-lang/setup-dafny-action@v1.6.1
         with:
           # A && B || C is the closest thing to an if .. then ... else ... or ?: expression the GitHub Actions syntax supports.
-          dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || '4.1.0' }}
+          dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || '4.2.0' }}
 
       - name: Build and locally deploy dependencies for examples
         shell: bash

--- a/.github/workflows/ci_test_java.yml
+++ b/.github/workflows/ci_test_java.yml
@@ -59,7 +59,7 @@ jobs:
         uses: dafny-lang/setup-dafny-action@v1.6.1
         with:
           # A && B || C is the closest thing to an if .. then ... else ... or ?: expression the GitHub Actions syntax supports.
-          dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || '4.1.0' }}
+          dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || '4.2.0' }}
 
       - name: Setup Java ${{ matrix.java-version }}
         uses: actions/setup-java@v3

--- a/.github/workflows/ci_test_net.yml
+++ b/.github/workflows/ci_test_net.yml
@@ -60,7 +60,7 @@ jobs:
         uses: dafny-lang/setup-dafny-action@v1.6.1
         with:
           # A && B || C is the closest thing to an if .. then ... else ... or ?: expression the GitHub Actions syntax supports.
-          dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || '4.1.0' }}
+          dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || '4.2.0' }}
 
       - name: Download Dependencies 
         working-directory: ./${{ matrix.library }}

--- a/.github/workflows/ci_test_vector_java.yml
+++ b/.github/workflows/ci_test_vector_java.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Dafny
         uses: dafny-lang/setup-dafny-action@v1.6.1
         with:
-          dafny-version: '4.1.0'
+          dafny-version: '4.2.0'
 
       - name: Setup Java ${{ matrix.java-version }}
         uses: actions/setup-java@v3

--- a/.github/workflows/ci_verification.yml
+++ b/.github/workflows/ci_verification.yml
@@ -50,7 +50,7 @@ jobs:
         uses: dafny-lang/setup-dafny-action@v1.6.1
         with:
           # A && B || C is the closest thing to an if .. then ... else ... or ?: expression the GitHub Actions syntax supports.
-          dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || '4.1.0' }}
+          dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || '4.2.0' }}
 
       - name: Verify ${{ matrix.library }} Dafny code
         shell: bash

--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -21,7 +21,7 @@ phases:
     commands:
       - cd ..
       # Get Dafny
-      - curl https://github.com/dafny-lang/dafny/releases/download/v4.1.0/dafny-4.1.0-x64-ubuntu-20.04.zip  -L -o dafny.zip
+      - curl https://github.com/dafny-lang/dafny/releases/download/v4.2.0/dafny-4.2.0-x64-ubuntu-20.04.zip  -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
       # Get Gradle 7.6

--- a/codebuild/release/validate-release.yml
+++ b/codebuild/release/validate-release.yml
@@ -14,7 +14,7 @@ phases:
     commands:
       - cd ..
       # Get Dafny
-      - curl https://github.com/dafny-lang/dafny/releases/download/v4.1.0/dafny-4.1.0-x64-ubuntu-20.04.zip  -L -o dafny.zip
+      - curl https://github.com/dafny-lang/dafny/releases/download/v4.2.0/dafny-4.2.0-x64-ubuntu-20.04.zip  -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
       # Get Gradle 7.6

--- a/codebuild/staging/release-staging.yml
+++ b/codebuild/staging/release-staging.yml
@@ -21,7 +21,7 @@ phases:
     commands:
       - cd ..
       # Get Dafny
-      - curl https://github.com/dafny-lang/dafny/releases/download/v4.1.0/dafny-4.1.0-x64-ubuntu-20.04.zip  -L -o dafny.zip
+      - curl https://github.com/dafny-lang/dafny/releases/download/v4.2.0/dafny-4.2.0-x64-ubuntu-20.04.zip  -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
       # Get Gradle 7.6

--- a/codebuild/staging/validate-staging.yml
+++ b/codebuild/staging/validate-staging.yml
@@ -18,7 +18,7 @@ phases:
     commands:
       - cd ..
       # Get Dafny
-      - curl https://github.com/dafny-lang/dafny/releases/download/v4.1.0/dafny-4.1.0-x64-ubuntu-20.04.zip  -L -o dafny.zip
+      - curl https://github.com/dafny-lang/dafny/releases/download/v4.2.0/dafny-4.2.0-x64-ubuntu-20.04.zip  -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
       # Get Gradle 7.6

--- a/project.properties
+++ b/project.properties
@@ -1,4 +1,4 @@
 projectJavaVersion=3.1.0
 mplDependencyJavaVersion=1.0.0
-dafnyRuntimeJavaVersion=4.1.0
+dafnyRuntimeJavaVersion=4.2.0
 smithyDafnyJavaConversionVersion=0.1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updates all CI references from Dafny 4.1 to Dafny 4.2.

See also: https://github.com/aws/aws-cryptographic-material-providers-library-java/pull/109 

Methodology: 

```
❯ grep -R '4.2' .github
.github/workflows/ci_test_vector_java.yml:          dafny-version: '4.2.0'
.github/workflows/ci_test_java.yml:          dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || '4.2.0' }}
.github/workflows/ci_examples_java.yml:          dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || '4.2.0' }}
.github/workflows/ci_verification.yml:          dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || '4.2.0' }}
.github/workflows/ci_test_net.yml:          dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || '4.2.0' }}
❯ grep -R '4.1' .github
❯
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
