### PR TITLE
fix: Move Java helper methods out of extern class

### DIFF
--- a/DynamoDbEncryption/dafny/DynamoDbItemEncryptor/src/InternalLegacyOverride.dfy
+++ b/DynamoDbEncryption/dafny/DynamoDbItemEncryptor/src/InternalLegacyOverride.dfy
@@ -22,43 +22,43 @@ module {:extern "software.amazon.cryptography.dbencryptionsdk.dynamodb.itemencry
 
     predicate method {:extern} IsLegacyInput(input: Types.DecryptItemInput)
 
-    // The following functions are for the benefit of the extern implementation to call,
-    // avoiding direct references to generic datatype constructors
-    // since their calling pattern is different between different versions of Dafny
-    // (i.e. after 4.2, explicit type descriptors are required).
+  }
 
-    static function method CreateBuildSuccess(value: Option<InternalLegacyOverride>): Result<Option<InternalLegacyOverride>, Types.Error> {
-      Success(value)
-    }
+  // The following functions are for the benefit of the extern implementation to call,
+  // avoiding direct references to generic datatype constructors
+  // since their calling pattern is different between different versions of Dafny
+  // (i.e. after 4.2, explicit type descriptors are required).
 
-    static function method CreateBuildFailure(error: Types.Error): Result<Option<InternalLegacyOverride>, Types.Error> {
-      Failure(error)
-    }
+  function method CreateBuildSuccess(value: Option<InternalLegacyOverride>): Result<Option<InternalLegacyOverride>, Types.Error> {
+    Success(value)
+  }
 
-    static function method CreateInternalLegacyOverrideSome(value: InternalLegacyOverride): Option<InternalLegacyOverride> {
-      Some(value)
-    }
+  function method CreateBuildFailure(error: Types.Error): Result<Option<InternalLegacyOverride>, Types.Error> {
+    Failure(error)
+  }
 
-    static function method CreateInternalLegacyOverrideNone(): Option<InternalLegacyOverride> {
-      None
-    }
+  function method CreateInternalLegacyOverrideSome(value: InternalLegacyOverride): Option<InternalLegacyOverride> {
+    Some(value)
+  }
 
-    function method CreateEncryptItemSuccess(value: Types.EncryptItemOutput): Result<Types.EncryptItemOutput, Types.Error> {
-      Success(value)
-    }
+  function method CreateInternalLegacyOverrideNone(): Option<InternalLegacyOverride> {
+    None
+  }
 
-    function method CreateEncryptItemFailure(error: Types.Error): Result<Types.EncryptItemOutput, Types.Error> {
-      Failure(error)
-    }
+  function method CreateEncryptItemSuccess(value: Types.EncryptItemOutput): Result<Types.EncryptItemOutput, Types.Error> {
+    Success(value)
+  }
 
-    function method CreateDecryptItemSuccess(value: Types.DecryptItemOutput): Result<Types.DecryptItemOutput, Types.Error> {
-      Success(value)
-    }
+  function method CreateEncryptItemFailure(error: Types.Error): Result<Types.EncryptItemOutput, Types.Error> {
+    Failure(error)
+  }
 
-    function method CreateDecryptItemFailure(error: Types.Error): Result<Types.DecryptItemOutput, Types.Error> {
-      Failure(error)
-    }
+  function method CreateDecryptItemSuccess(value: Types.DecryptItemOutput): Result<Types.DecryptItemOutput, Types.Error> {
+    Success(value)
+  }
 
+  function method CreateDecryptItemFailure(error: Types.Error): Result<Types.DecryptItemOutput, Types.Error> {
+    Failure(error)
   }
 
 }

--- a/DynamoDbEncryption/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/itemencryptor/internaldafny/legacy/InternalLegacyOverride.java
+++ b/DynamoDbEncryption/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/itemencryptor/internaldafny/legacy/InternalLegacyOverride.java
@@ -28,10 +28,9 @@ import java.util.stream.Collectors;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.cryptography.dbencryptionsdk.dynamodb.ILegacyDynamoDbEncryptor;
 import software.amazon.cryptography.dbencryptionsdk.dynamodb.internaldafny.types.LegacyPolicy;
+import software.amazon.cryptography.dbencryptionsdk.dynamodb.itemencryptor.internaldafny.legacy._ExternBase___default;
 import software.amazon.cryptography.dbencryptionsdk.dynamodb.itemencryptor.internaldafny.types.Error;
 import software.amazon.cryptography.dbencryptionsdk.structuredencryption.internaldafny.types.CryptoAction;
-
-import software.amazon.cryptography.dbencryptionsdk.dynamodb.itemencryptor.internaldafny.legacy._ExternBase___default;
 
 public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
 
@@ -130,7 +129,9 @@ public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
         );
       return _ExternBase___default.CreateEncryptItemSuccess(dafnyOutput);
     } catch (Exception ex) {
-      return _ExternBase___default.CreateEncryptItemFailure(Error.create_Opaque(ex));
+      return _ExternBase___default.CreateEncryptItemFailure(
+        Error.create_Opaque(ex)
+      );
     }
   }
 
@@ -183,7 +184,9 @@ public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
         );
       return _ExternBase___default.CreateDecryptItemSuccess(dafnyOutput);
     } catch (Exception ex) {
-      return _ExternBase___default.CreateDecryptItemFailure(Error.create_Opaque(ex));
+      return _ExternBase___default.CreateDecryptItemFailure(
+        Error.create_Opaque(ex)
+      );
     }
   }
 
@@ -192,7 +195,9 @@ public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
   ) {
     // Check for early return (Postcondition): If there is no legacyOverride there is nothing to do.
     if (encryptorConfig.dtor_legacyOverride().is_None()) {
-      return _ExternBase___default.CreateBuildSuccess(_ExternBase___default.CreateInternalLegacyOverrideNone());
+      return _ExternBase___default.CreateBuildSuccess(
+        _ExternBase___default.CreateInternalLegacyOverrideNone()
+      );
     }
     final software.amazon.cryptography.dbencryptionsdk.dynamodb.internaldafny.types.LegacyOverride legacyOverride =
       encryptorConfig.dtor_legacyOverride().dtor_value();
@@ -212,7 +217,9 @@ public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
     final InternalResult<EncryptionContext, Error> maybeEncryptionContext =
       legacyEncryptionContext(encryptorConfig);
     if (maybeEncryptionContext.isFailure()) {
-      return _ExternBase___default.CreateBuildFailure(maybeEncryptionContext.error());
+      return _ExternBase___default.CreateBuildFailure(
+        maybeEncryptionContext.error()
+      );
     }
     // Precondition: All actions MUST be supported types
     final InternalResult<
@@ -222,7 +229,9 @@ public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
       legacyOverride.dtor_attributeActionsOnEncrypt()
     );
     if (maybeActions.isFailure()) {
-      return _ExternBase___default.CreateBuildFailure(maybeEncryptionContext.error());
+      return _ExternBase___default.CreateBuildFailure(
+        maybeEncryptionContext.error()
+      );
     }
 
     final InternalLegacyOverride internalLegacyOverride =
@@ -234,7 +243,9 @@ public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
       );
 
     return _ExternBase___default.CreateBuildSuccess(
-            _ExternBase___default.CreateInternalLegacyOverrideSome(internalLegacyOverride)
+      _ExternBase___default.CreateInternalLegacyOverrideSome(
+        internalLegacyOverride
+      )
     );
   }
 

--- a/DynamoDbEncryption/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/itemencryptor/internaldafny/legacy/InternalLegacyOverride.java
+++ b/DynamoDbEncryption/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/itemencryptor/internaldafny/legacy/InternalLegacyOverride.java
@@ -28,9 +28,10 @@ import java.util.stream.Collectors;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.cryptography.dbencryptionsdk.dynamodb.ILegacyDynamoDbEncryptor;
 import software.amazon.cryptography.dbencryptionsdk.dynamodb.internaldafny.types.LegacyPolicy;
-import software.amazon.cryptography.dbencryptionsdk.dynamodb.itemencryptor.ToNative;
 import software.amazon.cryptography.dbencryptionsdk.dynamodb.itemencryptor.internaldafny.types.Error;
 import software.amazon.cryptography.dbencryptionsdk.structuredencryption.internaldafny.types.CryptoAction;
+
+import software.amazon.cryptography.dbencryptionsdk.dynamodb.itemencryptor.internaldafny.legacy._ExternBase___default;
 
 public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
 
@@ -95,7 +96,7 @@ public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
   ) {
     // Precondition: Policy MUST allow the caller to encrypt.
     if (!_policy.is_FORCE__LEGACY__ENCRYPT__ALLOW__LEGACY__DECRYPT()) {
-      return CreateEncryptItemFailure(
+      return _ExternBase___default.CreateEncryptItemFailure(
         createError("Legacy Policy does not support encrypt.")
       );
     }
@@ -127,9 +128,9 @@ public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
         software.amazon.cryptography.dbencryptionsdk.dynamodb.itemencryptor.ToDafny.EncryptItemOutput(
           nativeOutput
         );
-      return CreateEncryptItemSuccess(dafnyOutput);
+      return _ExternBase___default.CreateEncryptItemSuccess(dafnyOutput);
     } catch (Exception ex) {
-      return CreateEncryptItemFailure(Error.create_Opaque(ex));
+      return _ExternBase___default.CreateEncryptItemFailure(Error.create_Opaque(ex));
     }
   }
 
@@ -149,7 +150,7 @@ public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
       !_policy.is_FORCE__LEGACY__ENCRYPT__ALLOW__LEGACY__DECRYPT() &&
       !_policy.is_FORBID__LEGACY__ENCRYPT__ALLOW__LEGACY__DECRYPT()
     ) {
-      return CreateDecryptItemFailure(
+      return _ExternBase___default.CreateDecryptItemFailure(
         createError("Legacy Policy does not support decrypt.")
       );
     }
@@ -180,9 +181,9 @@ public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
         software.amazon.cryptography.dbencryptionsdk.dynamodb.itemencryptor.ToDafny.DecryptItemOutput(
           nativeOutput
         );
-      return CreateDecryptItemSuccess(dafnyOutput);
+      return _ExternBase___default.CreateDecryptItemSuccess(dafnyOutput);
     } catch (Exception ex) {
-      return CreateDecryptItemFailure(Error.create_Opaque(ex));
+      return _ExternBase___default.CreateDecryptItemFailure(Error.create_Opaque(ex));
     }
   }
 
@@ -191,7 +192,7 @@ public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
   ) {
     // Check for early return (Postcondition): If there is no legacyOverride there is nothing to do.
     if (encryptorConfig.dtor_legacyOverride().is_None()) {
-      return CreateBuildSuccess(CreateInternalLegacyOverrideNone());
+      return _ExternBase___default.CreateBuildSuccess(_ExternBase___default.CreateInternalLegacyOverrideNone());
     }
     final software.amazon.cryptography.dbencryptionsdk.dynamodb.internaldafny.types.LegacyOverride legacyOverride =
       encryptorConfig.dtor_legacyOverride().dtor_value();
@@ -203,7 +204,7 @@ public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
 
     // Precondition: The encryptor MUST be a DynamoDBEncryptor
     if (!isDynamoDBEncryptor(maybeEncryptor)) {
-      return CreateBuildFailure(
+      return _ExternBase___default.CreateBuildFailure(
         createError("Legacy encryptor is not supported")
       );
     }
@@ -211,7 +212,7 @@ public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
     final InternalResult<EncryptionContext, Error> maybeEncryptionContext =
       legacyEncryptionContext(encryptorConfig);
     if (maybeEncryptionContext.isFailure()) {
-      return CreateBuildFailure(maybeEncryptionContext.error());
+      return _ExternBase___default.CreateBuildFailure(maybeEncryptionContext.error());
     }
     // Precondition: All actions MUST be supported types
     final InternalResult<
@@ -221,7 +222,7 @@ public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
       legacyOverride.dtor_attributeActionsOnEncrypt()
     );
     if (maybeActions.isFailure()) {
-      return CreateBuildFailure(maybeEncryptionContext.error());
+      return _ExternBase___default.CreateBuildFailure(maybeEncryptionContext.error());
     }
 
     final InternalLegacyOverride internalLegacyOverride =
@@ -232,8 +233,8 @@ public class InternalLegacyOverride extends _ExternBase_InternalLegacyOverride {
         legacyOverride.dtor_policy()
       );
 
-    return CreateBuildSuccess(
-      CreateInternalLegacyOverrideSome(internalLegacyOverride)
+    return _ExternBase___default.CreateBuildSuccess(
+            _ExternBase___default.CreateInternalLegacyOverrideSome(internalLegacyOverride)
     );
   }
 


### PR DESCRIPTION
*Description of changes:*

I added these as a migration workaround for upgrading the Dafny version, but as a side effect this can make a class a mixed Dafny/native class when it wasn't intended to be, and this isn't supported on all target languages (e.g. Go). Easy fix to move them out of the class to the surrounding module instead.

Note that in this case `InternalLegacyOverride` was already a mixed class because of the `policy` constant, so a further refactoring will be necessary to support this in Go for e.g.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
