### PR TITLE
fix(.NET): Improve Collection of Errors string

### DIFF
--- a/DynamoDbEncryption/codegen-patches/DynamoDbEncryption/dotnet/dafny-4.9.0.patch
+++ b/DynamoDbEncryption/codegen-patches/DynamoDbEncryption/dotnet/dafny-4.9.0.patch
@@ -1,0 +1,74 @@
+diff --git b/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryption/CollectionOfErrors.cs a/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryption/CollectionOfErrors.cs
+index 84d4af9e..ca3d3174 100644
+--- b/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryption/CollectionOfErrors.cs
++++ a/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryption/CollectionOfErrors.cs
+@@ -8,9 +8,17 @@ namespace AWS.Cryptography.DbEncryptionSDK.DynamoDb
+   public class CollectionOfErrors : Exception
+   {
+     public readonly System.Collections.Generic.List<Exception> list;
+-    public CollectionOfErrors(System.Collections.Generic.List<Exception> list, string message) : base(message) { this.list = list; }
++    public CollectionOfErrors(System.Collections.Generic.List<Exception> list, string message) : base(message + $"\n List: \n{ListAsString(list)}") { this.list = list; }
+     public CollectionOfErrors(string message) : base(message) { this.list = new System.Collections.Generic.List<Exception>(); }
+     public CollectionOfErrors() : base("CollectionOfErrors") { this.list = new System.Collections.Generic.List<Exception>(); }
++    private static string ListAsString(List<Exception> list)
++    {
++      if (list.Count < 1) return "";
++      string[] msgArr = new string[list.Count];
++      for (int i = 0; i < list.Count; i++)
++        msgArr[i] = $"{list[i].GetType().Name} :: {list[i].Message}";
++      return String.Join("\n\t", msgArr);
++    }
+   }
+ 
+ }
+diff --git b/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryption/TypeConversion.cs a/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryption/TypeConversion.cs
+index 168c3a3d..b0542873 100644
+--- b/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryption/TypeConversion.cs
++++ a/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryption/TypeConversion.cs
+@@ -7,10 +7,43 @@ namespace AWS.Cryptography.DbEncryptionSDK.DynamoDb
+ {
+   public static class TypeConversion
+   {
+-    private const string ISO8601DateFormat = "yyyy-MM-dd\\THH:mm:ss.fff\\Z";
+-
+-    private const string ISO8601DateFormatNoMS = "yyyy-MM-dd\\THH:mm:ss\\Z";
++    // BEGIN MANUAL EDIT
++    public static AWS.Cryptography.KeyStore.KeyStore FromDafny_N3_aws__N12_cryptography__N15_dbEncryptionSdk__N8_dynamoDb__S17_KeyStoreReference(software.amazon.cryptography.keystore.internaldafny.types.IKeyStoreClient value)
++    {
++      if (value is software.amazon.cryptography.keystore.internaldafny.types.IKeyStoreClient dafnyValue)
++      {
++        return new AWS.Cryptography.KeyStore.KeyStore(dafnyValue);
++      }
++      throw new System.ArgumentException("Custom implementations of AWS.Cryptography.KeyStore.KeyStore are not supported yet");
++    }
++    public static software.amazon.cryptography.keystore.internaldafny.types.IKeyStoreClient ToDafny_N3_aws__N12_cryptography__N15_dbEncryptionSdk__N8_dynamoDb__S17_KeyStoreReference(AWS.Cryptography.KeyStore.KeyStore value)
++    {
++      if (value is AWS.Cryptography.KeyStore.KeyStore nativeValue)
++      {
++        return nativeValue.impl();
++      }
++      throw new System.ArgumentException("Custom implementations of AWS.Cryptography.KeyStore.KeyStore are not supported yet");
++    }
++    public static AWS.Cryptography.DbEncryptionSDK.DynamoDb.ILegacyDynamoDbEncryptor FromDafny_N3_aws__N12_cryptography__N15_dbEncryptionSdk__N8_dynamoDb__S32_LegacyDynamoDbEncryptorReference(software.amazon.cryptography.dbencryptionsdk.dynamodb.internaldafny.types.ILegacyDynamoDbEncryptor value)
++    {
++      if (value is NativeWrapper_LegacyDynamoDbEncryptor nativeWrapper) return nativeWrapper._impl;
++      return new LegacyDynamoDbEncryptor(value);
+ 
++    }
++    public static software.amazon.cryptography.dbencryptionsdk.dynamodb.internaldafny.types.ILegacyDynamoDbEncryptor ToDafny_N3_aws__N12_cryptography__N15_dbEncryptionSdk__N8_dynamoDb__S32_LegacyDynamoDbEncryptorReference(AWS.Cryptography.DbEncryptionSDK.DynamoDb.ILegacyDynamoDbEncryptor value)
++    {
++      switch (value)
++      {
++        case LegacyDynamoDbEncryptor valueWithImpl:
++          return valueWithImpl._impl;
++        case LegacyDynamoDbEncryptorBase nativeImpl:
++          return new NativeWrapper_LegacyDynamoDbEncryptor(nativeImpl);
++        default:
++          throw new System.ArgumentException(
++              "Custom implementations of LegacyDynamoDbEncryptor must extend LegacyDynamoDbEncryptorBase.");
++      }
++    }
++    // END MANUAL EDIT
+     public static AWS.Cryptography.DbEncryptionSDK.DynamoDb.BeaconKeySource FromDafny_N3_aws__N12_cryptography__N15_dbEncryptionSdk__N8_dynamoDb__S15_BeaconKeySource(software.amazon.cryptography.dbencryptionsdk.dynamodb.internaldafny.types._IBeaconKeySource value)
+     {
+       software.amazon.cryptography.dbencryptionsdk.dynamodb.internaldafny.types.BeaconKeySource concrete = (software.amazon.cryptography.dbencryptionsdk.dynamodb.internaldafny.types.BeaconKeySource)value;

--- a/DynamoDbEncryption/codegen-patches/DynamoDbEncryptionTransforms/dotnet/dafny-4.9.0.patch
+++ b/DynamoDbEncryption/codegen-patches/DynamoDbEncryptionTransforms/dotnet/dafny-4.9.0.patch
@@ -1,0 +1,38 @@
+diff --git b/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryptionTransforms/CollectionOfErrors.cs a/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryptionTransforms/CollectionOfErrors.cs
+index 6e2cf219..8fdaf86e 100644
+--- b/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryptionTransforms/CollectionOfErrors.cs
++++ a/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryptionTransforms/CollectionOfErrors.cs
+@@ -8,9 +8,17 @@ namespace AWS.Cryptography.DbEncryptionSDK.DynamoDb.Transforms
+   public class CollectionOfErrors : Exception
+   {
+     public readonly System.Collections.Generic.List<Exception> list;
+-    public CollectionOfErrors(System.Collections.Generic.List<Exception> list, string message) : base(message) { this.list = list; }
++    public CollectionOfErrors(System.Collections.Generic.List<Exception> list, string message) : base(message + $"\n List: \n{ListAsString(list)}") { this.list = list; }
+     public CollectionOfErrors(string message) : base(message) { this.list = new System.Collections.Generic.List<Exception>(); }
+     public CollectionOfErrors() : base("CollectionOfErrors") { this.list = new System.Collections.Generic.List<Exception>(); }
++    private static string ListAsString(List<Exception> list)
++    {
++      if (list.Count < 1) return "";
++      string[] msgArr = new string[list.Count];
++      for (int i = 0; i < list.Count; i++)
++        msgArr[i] = $"{list[i].GetType().Name} :: {list[i].Message}";
++      return String.Join("\n\t", msgArr);
++    }
+   }
+ 
+ }
+diff --git b/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryptionTransforms/TypeConversion.cs a/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryptionTransforms/TypeConversion.cs
+index 56470621..95841aee 100644
+--- b/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryptionTransforms/TypeConversion.cs
++++ a/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryptionTransforms/TypeConversion.cs
+@@ -7,10 +7,6 @@ namespace AWS.Cryptography.DbEncryptionSDK.DynamoDb.Transforms
+ {
+   public static class TypeConversion
+   {
+-    private const string ISO8601DateFormat = "yyyy-MM-dd\\THH:mm:ss.fff\\Z";
+-
+-    private const string ISO8601DateFormatNoMS = "yyyy-MM-dd\\THH:mm:ss\\Z";
+-
+     public static AWS.Cryptography.DbEncryptionSDK.DynamoDb.DynamoDbTablesEncryptionConfig FromDafny_N3_aws__N12_cryptography__N15_dbEncryptionSdk__N8_dynamoDb__S30_DynamoDbTablesEncryptionConfig(software.amazon.cryptography.dbencryptionsdk.dynamodb.internaldafny.types._IDynamoDbTablesEncryptionConfig value)
+     {
+       software.amazon.cryptography.dbencryptionsdk.dynamodb.internaldafny.types.DynamoDbTablesEncryptionConfig concrete = (software.amazon.cryptography.dbencryptionsdk.dynamodb.internaldafny.types.DynamoDbTablesEncryptionConfig)value; AWS.Cryptography.DbEncryptionSDK.DynamoDb.DynamoDbTablesEncryptionConfig converted = new AWS.Cryptography.DbEncryptionSDK.DynamoDb.DynamoDbTablesEncryptionConfig(); converted.TableEncryptionConfigs = (System.Collections.Generic.Dictionary<string, AWS.Cryptography.DbEncryptionSDK.DynamoDb.DynamoDbTableEncryptionConfig>)FromDafny_N3_aws__N12_cryptography__N15_dbEncryptionSdk__N8_dynamoDb__S30_DynamoDbTablesEncryptionConfig__M22_tableEncryptionConfigs(concrete._tableEncryptionConfigs); return converted;

--- a/DynamoDbEncryption/codegen-patches/DynamoDbItemEncryptor/dotnet/dafny-4.9.0.patch
+++ b/DynamoDbEncryption/codegen-patches/DynamoDbItemEncryptor/dotnet/dafny-4.9.0.patch
@@ -1,0 +1,39 @@
+diff --git b/DynamoDbEncryption/runtimes/net/Generated/DynamoDbItemEncryptor/CollectionOfErrors.cs a/DynamoDbEncryption/runtimes/net/Generated/DynamoDbItemEncryptor/CollectionOfErrors.cs
+index ef0d4752..acc77d97 100644
+--- b/DynamoDbEncryption/runtimes/net/Generated/DynamoDbItemEncryptor/CollectionOfErrors.cs
++++ a/DynamoDbEncryption/runtimes/net/Generated/DynamoDbItemEncryptor/CollectionOfErrors.cs
+@@ -8,9 +8,18 @@ namespace AWS.Cryptography.DbEncryptionSDK.DynamoDb.ItemEncryptor
+   public class CollectionOfErrors : Exception
+   {
+     public readonly System.Collections.Generic.List<Exception> list;
+-    public CollectionOfErrors(System.Collections.Generic.List<Exception> list, string message) : base(message) { this.list = list; }
++    public CollectionOfErrors(System.Collections.Generic.List<Exception> list, string message) : base(message + $"\n List: \n{ListAsString(list)}") { this.list = list; }
+     public CollectionOfErrors(string message) : base(message) { this.list = new System.Collections.Generic.List<Exception>(); }
+     public CollectionOfErrors() : base("CollectionOfErrors") { this.list = new System.Collections.Generic.List<Exception>(); }
++
++    private static string ListAsString(List<Exception> list)
++    {
++      if (list.Count < 1) return "";
++      string[] msgArr = new string[list.Count];
++      for (int i = 0; i < list.Count; i++)
++        msgArr[i] = $"{list[i].GetType().Name} :: {list[i].Message}";
++      return String.Join("\n\t", msgArr);
++    }
+   }
+ 
+ }
+diff --git b/DynamoDbEncryption/runtimes/net/Generated/DynamoDbItemEncryptor/TypeConversion.cs a/DynamoDbEncryption/runtimes/net/Generated/DynamoDbItemEncryptor/TypeConversion.cs
+index d1ceb19b..f96612ee 100644
+--- b/DynamoDbEncryption/runtimes/net/Generated/DynamoDbItemEncryptor/TypeConversion.cs
++++ a/DynamoDbEncryption/runtimes/net/Generated/DynamoDbItemEncryptor/TypeConversion.cs
+@@ -7,10 +7,6 @@ namespace AWS.Cryptography.DbEncryptionSDK.DynamoDb.ItemEncryptor
+ {
+   public static class TypeConversion
+   {
+-    private const string ISO8601DateFormat = "yyyy-MM-dd\\THH:mm:ss.fff\\Z";
+-
+-    private const string ISO8601DateFormatNoMS = "yyyy-MM-dd\\THH:mm:ss\\Z";
+-
+     public static AWS.Cryptography.DbEncryptionSDK.DynamoDb.ItemEncryptor.DecryptItemInput FromDafny_N3_aws__N12_cryptography__N15_dbEncryptionSdk__N8_dynamoDb__N13_itemEncryptor__S16_DecryptItemInput(software.amazon.cryptography.dbencryptionsdk.dynamodb.itemencryptor.internaldafny.types._IDecryptItemInput value)
+     {
+       software.amazon.cryptography.dbencryptionsdk.dynamodb.itemencryptor.internaldafny.types.DecryptItemInput concrete = (software.amazon.cryptography.dbencryptionsdk.dynamodb.itemencryptor.internaldafny.types.DecryptItemInput)value; AWS.Cryptography.DbEncryptionSDK.DynamoDb.ItemEncryptor.DecryptItemInput converted = new AWS.Cryptography.DbEncryptionSDK.DynamoDb.ItemEncryptor.DecryptItemInput(); converted.EncryptedItem = (System.Collections.Generic.Dictionary<string, Amazon.DynamoDBv2.Model.AttributeValue>)FromDafny_N3_aws__N12_cryptography__N15_dbEncryptionSdk__N8_dynamoDb__N13_itemEncryptor__S16_DecryptItemInput__M13_encryptedItem(concrete._encryptedItem); return converted;

--- a/DynamoDbEncryption/codegen-patches/StructuredEncryption/dotnet/dafny-4.9.0.patch
+++ b/DynamoDbEncryption/codegen-patches/StructuredEncryption/dotnet/dafny-4.9.0.patch
@@ -1,0 +1,38 @@
+diff --git b/DynamoDbEncryption/runtimes/net/Generated/StructuredEncryption/CollectionOfErrors.cs a/DynamoDbEncryption/runtimes/net/Generated/StructuredEncryption/CollectionOfErrors.cs
+index 0f4c3ff9..a966d3aa 100644
+--- b/DynamoDbEncryption/runtimes/net/Generated/StructuredEncryption/CollectionOfErrors.cs
++++ a/DynamoDbEncryption/runtimes/net/Generated/StructuredEncryption/CollectionOfErrors.cs
+@@ -8,9 +8,17 @@ namespace AWS.Cryptography.DbEncryptionSDK.StructuredEncryption
+   public class CollectionOfErrors : Exception
+   {
+     public readonly System.Collections.Generic.List<Exception> list;
+-    public CollectionOfErrors(System.Collections.Generic.List<Exception> list, string message) : base(message) { this.list = list; }
++    public CollectionOfErrors(System.Collections.Generic.List<Exception> list, string message) : base(message + $"\n List: \n{ListAsString(list)}") { this.list = list; }
+     public CollectionOfErrors(string message) : base(message) { this.list = new System.Collections.Generic.List<Exception>(); }
+     public CollectionOfErrors() : base("CollectionOfErrors") { this.list = new System.Collections.Generic.List<Exception>(); }
++    private static string ListAsString(List<Exception> list)
++    {
++      if (list.Count < 1) return "";
++      string[] msgArr = new string[list.Count];
++      for (int i = 0; i < list.Count; i++)
++        msgArr[i] = $"{list[i].GetType().Name} :: {list[i].Message}";
++      return String.Join("\n\t", msgArr);
++    }
+   }
+ 
+ }
+diff --git b/DynamoDbEncryption/runtimes/net/Generated/StructuredEncryption/TypeConversion.cs a/DynamoDbEncryption/runtimes/net/Generated/StructuredEncryption/TypeConversion.cs
+index 6de665f3..6a802466 100644
+--- b/DynamoDbEncryption/runtimes/net/Generated/StructuredEncryption/TypeConversion.cs
++++ a/DynamoDbEncryption/runtimes/net/Generated/StructuredEncryption/TypeConversion.cs
+@@ -7,10 +7,6 @@ namespace AWS.Cryptography.DbEncryptionSDK.StructuredEncryption
+ {
+   public static class TypeConversion
+   {
+-    private const string ISO8601DateFormat = "yyyy-MM-dd\\THH:mm:ss.fff\\Z";
+-
+-    private const string ISO8601DateFormatNoMS = "yyyy-MM-dd\\THH:mm:ss\\Z";
+-
+     public static AWS.Cryptography.DbEncryptionSDK.StructuredEncryption.AuthenticateAction FromDafny_N3_aws__N12_cryptography__N15_dbEncryptionSdk__N20_structuredEncryption__S18_AuthenticateAction(software.amazon.cryptography.dbencryptionsdk.structuredencryption.internaldafny.types._IAuthenticateAction value)
+     {
+       if (value.is_SIGN) return AWS.Cryptography.DbEncryptionSDK.StructuredEncryption.AuthenticateAction.SIGN;

--- a/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryption/CollectionOfErrors.cs
+++ b/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryption/CollectionOfErrors.cs
@@ -8,9 +8,17 @@ namespace AWS.Cryptography.DbEncryptionSDK.DynamoDb
   public class CollectionOfErrors : Exception
   {
     public readonly System.Collections.Generic.List<Exception> list;
-    public CollectionOfErrors(System.Collections.Generic.List<Exception> list, string message) : base(message) { this.list = list; }
+    public CollectionOfErrors(System.Collections.Generic.List<Exception> list, string message) : base(message + $"\n List: \n{ListAsString(list)}") { this.list = list; }
     public CollectionOfErrors(string message) : base(message) { this.list = new System.Collections.Generic.List<Exception>(); }
     public CollectionOfErrors() : base("CollectionOfErrors") { this.list = new System.Collections.Generic.List<Exception>(); }
+    private static string ListAsString(List<Exception> list)
+    {
+      if (list.Count < 1) return "";
+      string[] msgArr = new string[list.Count];
+      for (int i = 0; i < list.Count; i++)
+        msgArr[i] = $"{list[i].GetType().Name} :: {list[i].Message}";
+      return String.Join("\n\t", msgArr);
+    }
   }
 
 }

--- a/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryptionTransforms/CollectionOfErrors.cs
+++ b/DynamoDbEncryption/runtimes/net/Generated/DynamoDbEncryptionTransforms/CollectionOfErrors.cs
@@ -8,9 +8,17 @@ namespace AWS.Cryptography.DbEncryptionSDK.DynamoDb.Transforms
   public class CollectionOfErrors : Exception
   {
     public readonly System.Collections.Generic.List<Exception> list;
-    public CollectionOfErrors(System.Collections.Generic.List<Exception> list, string message) : base(message) { this.list = list; }
+    public CollectionOfErrors(System.Collections.Generic.List<Exception> list, string message) : base(message + $"\n List: \n{ListAsString(list)}") { this.list = list; }
     public CollectionOfErrors(string message) : base(message) { this.list = new System.Collections.Generic.List<Exception>(); }
     public CollectionOfErrors() : base("CollectionOfErrors") { this.list = new System.Collections.Generic.List<Exception>(); }
+    private static string ListAsString(List<Exception> list)
+    {
+      if (list.Count < 1) return "";
+      string[] msgArr = new string[list.Count];
+      for (int i = 0; i < list.Count; i++)
+        msgArr[i] = $"{list[i].GetType().Name} :: {list[i].Message}";
+      return String.Join("\n\t", msgArr);
+    }
   }
 
 }

--- a/DynamoDbEncryption/runtimes/net/Generated/DynamoDbItemEncryptor/CollectionOfErrors.cs
+++ b/DynamoDbEncryption/runtimes/net/Generated/DynamoDbItemEncryptor/CollectionOfErrors.cs
@@ -8,9 +8,18 @@ namespace AWS.Cryptography.DbEncryptionSDK.DynamoDb.ItemEncryptor
   public class CollectionOfErrors : Exception
   {
     public readonly System.Collections.Generic.List<Exception> list;
-    public CollectionOfErrors(System.Collections.Generic.List<Exception> list, string message) : base(message) { this.list = list; }
+    public CollectionOfErrors(System.Collections.Generic.List<Exception> list, string message) : base(message + $"\n List: \n{ListAsString(list)}") { this.list = list; }
     public CollectionOfErrors(string message) : base(message) { this.list = new System.Collections.Generic.List<Exception>(); }
     public CollectionOfErrors() : base("CollectionOfErrors") { this.list = new System.Collections.Generic.List<Exception>(); }
+
+    private static string ListAsString(List<Exception> list)
+    {
+      if (list.Count < 1) return "";
+      string[] msgArr = new string[list.Count];
+      for (int i = 0; i < list.Count; i++)
+        msgArr[i] = $"{list[i].GetType().Name} :: {list[i].Message}";
+      return String.Join("\n\t", msgArr);
+    }
   }
 
 }

--- a/DynamoDbEncryption/runtimes/net/Generated/StructuredEncryption/CollectionOfErrors.cs
+++ b/DynamoDbEncryption/runtimes/net/Generated/StructuredEncryption/CollectionOfErrors.cs
@@ -8,9 +8,17 @@ namespace AWS.Cryptography.DbEncryptionSDK.StructuredEncryption
   public class CollectionOfErrors : Exception
   {
     public readonly System.Collections.Generic.List<Exception> list;
-    public CollectionOfErrors(System.Collections.Generic.List<Exception> list, string message) : base(message) { this.list = list; }
+    public CollectionOfErrors(System.Collections.Generic.List<Exception> list, string message) : base(message + $"\n List: \n{ListAsString(list)}") { this.list = list; }
     public CollectionOfErrors(string message) : base(message) { this.list = new System.Collections.Generic.List<Exception>(); }
     public CollectionOfErrors() : base("CollectionOfErrors") { this.list = new System.Collections.Generic.List<Exception>(); }
+    private static string ListAsString(List<Exception> list)
+    {
+      if (list.Count < 1) return "";
+      string[] msgArr = new string[list.Count];
+      for (int i = 0; i < list.Count; i++)
+        msgArr[i] = $"{list[i].GetType().Name} :: {list[i].Message}";
+      return String.Join("\n\t", msgArr);
+    }
   }
 
 }


### PR DESCRIPTION
*Issue #, if available:*

Collection of Errors is a frustrating error because it requires customer action
to completely serialize it into logs.

We can make a simple fix in .NET to improve the CX,
by always serializing the list into the Collection Of Error's
message.

We concatenate the given error message with
a serialization of all the nested errors.

See similar PR for MPL-Java: https://github.com/aws/aws-cryptographic-material-providers-library/commit/9e195a1960fa18e1dc6efd0c9057c2ec6aed8e11

*Squash/merge commit message, if applicable:*
```
fix(.NET): Improve Collection of Errors string 
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
