### PR TITLE
fix(net): pin aws-sdk version < 4.x

### DIFF
--- a/.github/workflows/ci_examples_java.yml
+++ b/.github/workflows/ci_examples_java.yml
@@ -45,6 +45,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      
+      - name: Setup Java 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: "corretto"
+          java-version: 8
 
       - name: Setup Java ${{ matrix.java-version }}
         uses: actions/setup-java@v4

--- a/.github/workflows/ci_examples_java.yml
+++ b/.github/workflows/ci_examples_java.yml
@@ -45,11 +45,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: '7.6'  # Supports Java 8-17
+          gradle-version: "7.6" # Supports Java 8-17
           cache-read-only: false
 
       - name: Setup Java ${{ matrix.java-version }}

--- a/.github/workflows/ci_examples_java.yml
+++ b/.github/workflows/ci_examples_java.yml
@@ -46,11 +46,11 @@ jobs:
         with:
           submodules: recursive
       
-      - name: Setup Java 8
-        uses: actions/setup-java@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
         with:
-          distribution: "corretto"
-          java-version: 8
+          gradle-version: '7.6'  # Supports Java 8-17
+          cache-read-only: false
 
       - name: Setup Java ${{ matrix.java-version }}
         uses: actions/setup-java@v4

--- a/.github/workflows/library_rust_tests.yml
+++ b/.github/workflows/library_rust_tests.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Dafny
         uses: dafny-lang/setup-dafny-action@v1.7.0
         with:
-          dafny-version: nightly-2024-12-03-4954170
+          dafny-version: 4.10.0
 
       - name: Update MPL submodule if using MPL HEAD
         if: ${{ inputs.mpl-head == true }}

--- a/.github/workflows/library_rust_tests.yml
+++ b/.github/workflows/library_rust_tests.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Setup Rust Toolchain for GitHub CI
         uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
         with:
+          toolchain: 1.86.0
           components: rustfmt
       # uncomment this after Rust formatter works
       # - name: Rustfmt Check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.7.1]
+
+Pin DynamoDb and aws sdk version < 4.x
+
 ## [3.7.0](https://github.com/aws/aws-database-encryption-sdk-dynamodb/compare/v3.6.2...v3.7.0) (2024-09-17)
 
 ### Features

--- a/DynamoDbEncryption/dafny/DynamoDbEncryption/test/DynamoDbEncryptionBranchKeyIdSupplierTest.dfy
+++ b/DynamoDbEncryption/dafny/DynamoDbEncryption/test/DynamoDbEncryptionBranchKeyIdSupplierTest.dfy
@@ -26,7 +26,7 @@ module DynamoDbEncryptionBranchKeyIdSupplierTest {
   const logicalKeyStoreName := branchKeyStoreName
 
   // These tests require a keystore populated with a key with this Id
-  const BRANCH_KEY_ID := "75789115-1deb-4fe3-a2ec-be9e885d1945"
+  const BRANCH_KEY_ID := "3f43a9af-08c5-4317-b694-3d3e883dcaef"
   const BRANCH_KEY_ID_UTF8 := UTF8.EncodeAscii(BRANCH_KEY_ID)
   const ALTERNATE_BRANCH_KEY_ID := "4bb57643-07c1-419e-92ad-0df0df149d7c"
 

--- a/DynamoDbEncryption/runtimes/java/README.md
+++ b/DynamoDbEncryption/runtimes/java/README.md
@@ -59,7 +59,6 @@ To use the DB-ESDK for DynamoDB in Java, you must have:
 
   The KMS and DynamoDB-Enhanced Clients from the AWS SDK For Java V2
   are **optional** dependencies.
-
   - **Via Gradle Kotlin**  
     In a Gradle Java Project, add the following to the _dependencies_ section:
 

--- a/DynamoDbEncryption/runtimes/java/src/test/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/TestUtils.java
+++ b/DynamoDbEncryption/runtimes/java/src/test/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/TestUtils.java
@@ -34,7 +34,7 @@ public class TestUtils {
   public static final String TEST_KEY_STORE_KMS_KEY =
     "arn:aws:kms:us-west-2:370957321024:key/9d989aa2-2f9c-438c-a745-cc57d3ad0126";
   public static final String BRANCH_KEY_ID =
-    "75789115-1deb-4fe3-a2ec-be9e885d1945";
+    "3f43a9af-08c5-4317-b694-3d3e883dcaef";
   public static final String ALTERNATE_BRANCH_KEY_ID =
     "4bb57643-07c1-419e-92ad-0df0df149d7c";
 

--- a/DynamoDbEncryption/runtimes/net/AssemblyInfo.cs
+++ b/DynamoDbEncryption/runtimes/net/AssemblyInfo.cs
@@ -3,5 +3,5 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.DbEncryptionSDK.DynamoDb")]
 
 // This should be kept in sync with the version number in MPL.csproj
-[assembly: AssemblyVersion("3.7.0")]
+[assembly: AssemblyVersion("3.7.1")]
 

--- a/DynamoDbEncryption/runtimes/net/DynamoDbEncryption.csproj
+++ b/DynamoDbEncryption/runtimes/net/DynamoDbEncryption.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
 
-    <Version>3.7.0</Version>
+    <Version>3.7.1</Version>
 
     <AssemblyName>AWS.Cryptography.DbEncryptionSDK.DynamoDb</AssemblyName>
     <PackageId>AWS.Cryptography.DbEncryptionSDK.DynamoDb</PackageId>
@@ -57,8 +57,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.402.2"/>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.400.38"/>
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="[3.7.*, 4.0)" />
     <PackageReference Include="DafnyRuntime" Version="$(DafnyVersion)" />
     <ProjectReference Include="../../../submodules/MaterialProviders/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj"/>
     <!--

--- a/DynamoDbEncryption/runtimes/rust/Cargo.toml
+++ b/DynamoDbEncryption/runtimes/rust/Cargo.toml
@@ -25,7 +25,7 @@ aws-smithy-runtime-api = {version = "1.7.3", features = ["client"] }
 aws-smithy-types = "1.2.10"
 chrono = "0.4.39"
 cpu-time = "1.0.0"
-dafny-runtime = "0.1.1"
+dafny-runtime = "0.2.0"
 dashmap = "6.1.0"
 pem = "3.0.4"
 tokio = {version = "1.42.0", features = ["full"] }
@@ -33,3 +33,6 @@ uuid = { version = "1.11.0", features = ["v4"] }
 
 [[example]]
 name = "main"
+
+[lints.rust]
+deprecated = "allow"

--- a/TestVectors/runtimes/rust/Cargo.toml
+++ b/TestVectors/runtimes/rust/Cargo.toml
@@ -16,8 +16,11 @@ aws-smithy-runtime-api = {version = "1.7.3", features = ["client"] }
 aws-smithy-types = "1.2.10"
 chrono = "0.4.39"
 cpu-time = "1.0.0"
-dafny_runtime = { path = "../../../submodules/MaterialProviders/smithy-dafny/TestModels/dafny-dependencies/dafny_runtime_rust"}
+dafny-runtime = "0.2.0"
 dashmap = "6.1.0"
 pem = "3.0.4"
 tokio = {version = "1.42.0", features = ["full"] }
 uuid = { version = "1.11.0", features = ["v4"] }
+
+[lints.rust]
+deprecated = "allow"

--- a/specification/dynamodb-encryption-client/ddb-attribute-serialization.md
+++ b/specification/dynamodb-encryption-client/ddb-attribute-serialization.md
@@ -10,7 +10,6 @@
 ### Changelog
 
 - 1.0.0
-
   - Initial record
 
 ## Definitions

--- a/specification/dynamodb-encryption-client/ddb-item-conversion.md
+++ b/specification/dynamodb-encryption-client/ddb-item-conversion.md
@@ -10,7 +10,6 @@
 ### Changelog
 
 - 1.0.0
-
   - Initial record
 
 ## Definitions

--- a/specification/dynamodb-encryption-client/ddb-item-encryptor.md
+++ b/specification/dynamodb-encryption-client/ddb-item-encryptor.md
@@ -10,7 +10,6 @@
 ### Changelog
 
 - 1.0.0
-
   - Initial record
 
 ## Definitions

--- a/specification/dynamodb-encryption-client/ddb-sdk-integration.md
+++ b/specification/dynamodb-encryption-client/ddb-sdk-integration.md
@@ -10,7 +10,6 @@
 ### Changelog
 
 - 1.0.0
-
   - Initial record
 
 ## Definitions

--- a/specification/dynamodb-encryption-client/ddb-table-encryption-config.md
+++ b/specification/dynamodb-encryption-client/ddb-table-encryption-config.md
@@ -10,7 +10,6 @@
 ### Changelog
 
 - 1.0.0
-
   - Initial record
 
 ## Definitions

--- a/specification/dynamodb-encryption-client/decrypt-item.md
+++ b/specification/dynamodb-encryption-client/decrypt-item.md
@@ -10,7 +10,6 @@
 ### Changelog
 
 - 1.0.0
-
   - Initial record
 
 ## Definitions

--- a/specification/dynamodb-encryption-client/encrypt-item.md
+++ b/specification/dynamodb-encryption-client/encrypt-item.md
@@ -10,7 +10,6 @@
 ### Changelog
 
 - 1.0.0
-
   - Initial record
 
 ## Definitions

--- a/specification/dynamodb-encryption-client/string-ordering.md
+++ b/specification/dynamodb-encryption-client/string-ordering.md
@@ -10,7 +10,6 @@
 ### Changelog
 
 - 1.0.0
-
   - Initial record
 
 ## Definitions

--- a/specification/structured-encryption/decrypt-path-structure.md
+++ b/specification/structured-encryption/decrypt-path-structure.md
@@ -10,7 +10,6 @@
 ### Changelog
 
 - 1.0.0
-
   - Initial record
 
 ## Definitions

--- a/specification/structured-encryption/decrypt-structure.md
+++ b/specification/structured-encryption/decrypt-structure.md
@@ -10,7 +10,6 @@
 ### Changelog
 
 - 1.1.0
-
   - Update for simplified structured encryption
 
 - 1.0.0

--- a/specification/structured-encryption/encrypt-path-structure.md
+++ b/specification/structured-encryption/encrypt-path-structure.md
@@ -10,7 +10,6 @@
 ### Changelog
 
 - 1.0.0
-
   - Initial record
 
 ## Definitions

--- a/specification/structured-encryption/encrypt-structure.md
+++ b/specification/structured-encryption/encrypt-structure.md
@@ -10,7 +10,6 @@
 ### Changelog
 
 - 1.1.0
-
   - Update for simplified structured encryption
 
 - 1.0.0

--- a/specification/structured-encryption/resolve-auth-actions.md
+++ b/specification/structured-encryption/resolve-auth-actions.md
@@ -10,7 +10,6 @@
 ### Changelog
 
 - 1.0.0
-
   - Initial record
 
 ## Definitions

--- a/specification/structured-encryption/structures.md
+++ b/specification/structured-encryption/structures.md
@@ -10,7 +10,6 @@
 ### Changelog
 
 - 1.1.0
-
   - Update for simplified structured encryption
 
 - 1.0.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Fixes the aws-sdk version
2. Fixes formatting
3. Rust and java changes to allow interop CI
4. Text fixes to use the latest data / key.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
