### PR TITLE
chore(ci): add workflow dispatch for daily CI of v3 branch

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -152,6 +152,6 @@ jobs:
     if: ${{ failure() && github.event_name == 'schedule'}}
     uses: aws/aws-cryptographic-material-providers-library/.github/workflows/slack-notification.yml@main
     with:
-      message: "Daily CI failed on `${{ github.repository }}`. View run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      message: "Daily CI for branch v3.x-Java branch failed on `${{ github.repository }}`. View run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_CI }}

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -6,8 +6,7 @@ permissions:
   id-token: write
 
 on:
-  schedule:
-    - cron: "00 16 * * 1-5"
+  workflow_dispatch:
   pull_request:
     paths: .github/workflows/daily_ci.yml
 


### PR DESCRIPTION
## How daily CI in v3.xJava Works?

1. **13:00 UTC weekday** — GitHub fires `daily_ci_java_3x.yml` on `main` (schedule only runs from default branch). This is just the dispatcher.

2. **The dispatcher job runs** — it calls the GitHub API:
   ```
   createWorkflowDispatch({
     workflow_id: 'daily_ci.yml',
     ref: 'v3.x-Java'
   })
   ```
   This tells GitHub: "trigger `daily_ci.yml` on branch `v3.x-Java`."

3. **GitHub receives the API call** — it looks at `daily_ci.yml` on the `v3.x-Java` branch and checks: "does this workflow accept `workflow_dispatch` as a trigger?" If yes, it starts a new workflow run. If no, the API call fails.

4. **GitHub starts a new run of `daily_ci.yml`** — this run is associated with `v3.x-Java`, not `main`. So when the jobs do `actions/checkout` (with no `ref`), they check out `v3.x-Java` code.

5. **Result**: Two separate workflow runs happen — the dispatcher (on `main`) and the real CI (on `v3.x-Java`). All reusable workflows run against `v3.x-Java` without any modifications.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
