### PR TITLE
chore(ci): trigger daily CI in v3.x-java branch 

### DIFF
--- a/.github/workflows/daily_ci_java_3x.yml
+++ b/.github/workflows/daily_ci_java_3x.yml
@@ -1,0 +1,43 @@
+name: Daily CI (main-dbesdk-java-v3.0)
+
+on:
+  schedule:
+    - cron: "00 13 * * 1-5"
+  workflow_dispatch:
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail after end of support
+        run: |
+          CUTOFF="2026-08-01"
+          NOW=$(date -u +%Y-%m-%d)
+          if [[ "$NOW" > "$CUTOFF" || "$NOW" == "$CUTOFF" ]]; then
+            echo "CI disabled as v3.x is end of support after $CUTOFF"
+            exit 1
+          fi
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'daily_ci.yml',
+              ref: 'main-dbesdk-java-v3.0'
+            });
+  notify:
+    permissions:
+        contents: read
+        pull-requests: write
+        id-token: write
+    needs:
+        [
+        trigger
+        ]
+    if: ${{ failure() && github.event_name == 'schedule'}}
+    uses: aws/aws-cryptographic-material-providers-library/.github/workflows/slack-notification.yml@main
+    with:
+        message: "Failed to trigger Daily CI for branch v3.x-Java (see daily_ci_java_3x.yml on main) on `${{ github.repository }}`. View run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+    secrets:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_CI }}

--- a/.github/workflows/daily_ci_java_3x.yml
+++ b/.github/workflows/daily_ci_java_3x.yml
@@ -3,7 +3,12 @@ name: Daily CI (main-dbesdk-java-v3.0)
 on:
   schedule:
     - cron: "00 13 * * 1-5"
-  workflow_dispatch:
+  pull_request:
+    paths: .github/workflows/daily_ci_java_3x.yml
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   trigger:

--- a/.github/workflows/daily_ci_java_3x.yml
+++ b/.github/workflows/daily_ci_java_3x.yml
@@ -32,7 +32,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'daily_ci.yml',
-              ref: 'main-dbesdk-java-v3.0'
+              ref: 'v3.x-Java'
             });
   notify:
     permissions:

--- a/.github/workflows/daily_ci_java_3x.yml
+++ b/.github/workflows/daily_ci_java_3x.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   trigger:
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Fail after end of support

--- a/.github/workflows/daily_ci_java_3x.yml
+++ b/.github/workflows/daily_ci_java_3x.yml
@@ -28,16 +28,13 @@ jobs:
             });
   notify:
     permissions:
-        contents: read
-        pull-requests: write
-        id-token: write
-    needs:
-        [
-        trigger
-        ]
+      contents: read
+      pull-requests: write
+      id-token: write
+    needs: [trigger]
     if: ${{ failure() && github.event_name == 'schedule'}}
     uses: aws/aws-cryptographic-material-providers-library/.github/workflows/slack-notification.yml@main
     with:
-        message: "Failed to trigger Daily CI for branch v3.x-Java (see daily_ci_java_3x.yml on main) on `${{ github.repository }}`. View run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      message: "Failed to trigger Daily CI for branch v3.x-Java (see daily_ci_java_3x.yml on main) on `${{ github.repository }}`. View run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
     secrets:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_CI }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_CI }}

--- a/.github/workflows/daily_ci_java_3x.yml
+++ b/.github/workflows/daily_ci_java_3x.yml
@@ -1,4 +1,4 @@
-name: Daily CI (main-dbesdk-java-v3.0)
+name: Daily CI (v3.x-java)
 
 on:
   schedule:


### PR DESCRIPTION
## How daily CI in v3.xJava Works?

1. **13:00 UTC weekday** — GitHub fires `daily_ci_java_3x.yml` on `main` (schedule only runs from default branch). This is just the dispatcher.

2. **The dispatcher job runs** — it calls the GitHub API:
   ```
   createWorkflowDispatch({
     workflow_id: 'daily_ci.yml',
     ref: 'v3.x-Java'
   })
   ```
   This tells GitHub: "trigger `daily_ci.yml` on branch `v3.x-Java`."

3. **GitHub receives the API call** — it looks at `daily_ci.yml` on the `v3.x-Java` branch and checks: "does this workflow accept `workflow_dispatch` as a trigger?" If yes, it starts a new workflow run. If no, the API call fails.

4. **GitHub starts a new run of `daily_ci.yml`** — this run is associated with `v3.x-Java`, not `main`. So when the jobs do `actions/checkout` (with no `ref`), they check out `v3.x-Java` code.

5. **Result**: Two separate workflow runs happen — the dispatcher (on `main`) and the real CI (on `v3.x-Java`). All reusable workflows run against `v3.x-Java` without any modifications.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
