### PR TITLE
chore(java): attempt to reduce flaky CI failures

### DIFF
--- a/.github/workflows/ci_test_vector_java.yml
+++ b/.github/workflows/ci_test_vector_java.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   testJava:
     strategy:
+      fail-fast: false
       matrix:
         library: [TestVectors]
         java-version: [8, 11, 17, 19]

--- a/DynamoDbEncryption/runtimes/java/src/test/sdkv1/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/CachingMostRecentProviderTests.java
+++ b/DynamoDbEncryption/runtimes/java/src/test/sdkv1/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/CachingMostRecentProviderTests.java
@@ -190,8 +190,9 @@ public class CachingMostRecentProviderTests {
       0,
       store.getVersionFromMaterialDescription(eMat2.getMaterialDescription())
     );
-    // Let the TTL be exceeded
-    Thread.sleep(500);
+    // Let the TTL be exceeded; sleep must be > TTL (500ms) to reliably
+    // land in the grace period and trigger a cache refresh.
+    Thread.sleep(700);
     final EncryptionMaterials eMat3 = prov.getEncryptionMaterials(ctx);
     assertEquals(2, methodCalls.size());
     assertEquals(1, (int) methodCalls.getOrDefault("query", 0)); // To find current version
@@ -356,8 +357,9 @@ public class CachingMostRecentProviderTests {
       "Expected no calls but was " + methodCalls.toString(),
       methodCalls.isEmpty()
     );
-    // Let the TTL be exceeded
-    Thread.sleep(500);
+    // Let the TTL be exceeded; sleep must be > TTL (500ms) to reliably
+    // land in the grace period and trigger a cache refresh.
+    Thread.sleep(700);
     final EncryptionMaterials eMat3 = prov.getEncryptionMaterials(ctx);
 
     assertEquals(1, (int) methodCalls.getOrDefault("query", 0)); // To find current version
@@ -512,8 +514,9 @@ public class CachingMostRecentProviderTests {
       store.getVersionFromMaterialDescription(eMat2_2.getMaterialDescription())
     );
 
-    // Let the TTL be exceeded
-    Thread.sleep(500);
+    // Let the TTL be exceeded; sleep must be > TTL (500ms) to reliably
+    // land in the grace period and trigger a cache refresh.
+    Thread.sleep(700);
     final EncryptionMaterials eMat3_1 = prov.getEncryptionMaterials(ctx1);
     assertEquals(2, methodCalls.size());
     assertEquals(1, (int) methodCalls.get("query")); // To find current version


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
TTL is set as 500 ms which is also the cache expiration time. However, there is a grace period in some cases in cache expiration time and hence we should wait for more than 500 ms in our tests. We do have other tests where it is waiting for 700 ms. This change aims to make sleep time consistent across.

Changes also sets fail fast to false to ensure all failures are caught at once.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
