### PR TITLE
chore(ci): add workflow_dispatch and remove run on PR for daily CI

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -8,8 +8,7 @@ permissions:
 on:
   schedule:
     - cron: "00 16 * * 1-5"
-  pull_request:
-    paths: .github/workflows/daily_ci.yml
+  workflow_dispatch:
 
 jobs:
   getVersion:


### PR DESCRIPTION
*Issue #, if available:*
When Daily CI ran in `ddbec-with-sdk-v2` it failed because it want to run `ddbec-with-sdk-v2` examples which is not there in main.

*Description of changes:*
Instead of run on PR. We will give option to workflow dispatch when its merged it main.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
