### PR TITLE
chore(java): Attempt to reduce flaky CI

### DIFF
--- a/.github/workflows/ci_test_vector_java.yml
+++ b/.github/workflows/ci_test_vector_java.yml
@@ -56,6 +56,14 @@ jobs:
         if: matrix.os == 'macos-15-intel' && matrix.library == 'TestVectors'
         uses: douglascamata/setup-docker-macos-action@v1.1.0
 
+      - name: Pre-pull DynamoDB Local image with retry
+        if: matrix.library == 'TestVectors'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: docker pull amazon/dynamodb-local:latest
+
       - name: Setup DynamoDB Local
         if: matrix.library == 'TestVectors'
         uses: rrainn/dynamodb-action@v4.0.0

--- a/DynamoDbEncryption/runtimes/java/src/test/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/DynamoDbEncryptionInterceptorIntegrationTests.java
+++ b/DynamoDbEncryption/runtimes/java/src/test/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/DynamoDbEncryptionInterceptorIntegrationTests.java
@@ -394,7 +394,7 @@ public class DynamoDbEncryptionInterceptorIntegrationTests {
     // Put Item into table via transactions
     HashMap<String, AttributeValue> item = new HashMap<>();
 
-    String partitionValue = "transact";
+    String partitionValue = "transact" + randomNum;
     String sortValue1 = "1";
     String sortValue2 = "2";
     String attrValue = "lorem ipsum";

--- a/cfn/CI.yaml
+++ b/cfn/CI.yaml
@@ -60,6 +60,7 @@ Resources:
         - AttributeName: "sort_key"
           KeyType: "RANGE"
       TableName: !Ref TableName
+      BillingMode: PAY_PER_REQUEST
 
   # These tables were manually created but not used in CI
   # If we have to start using them in CI we just have to add
@@ -102,9 +103,6 @@ Resources:
               KeyType: "HASH"
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            ReadCapacityUnits: "5"
-            WriteCapacityUnits: "5"
         - IndexName: "state-zip-index"
           KeySchema:
             - AttributeName: "aws_dbe_b_state"
@@ -113,36 +111,24 @@ Resources:
               KeyType: "RANGE"
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            ReadCapacityUnits: "5"
-            WriteCapacityUnits: "5"
         - IndexName: "location-index"
           KeySchema:
             - AttributeName: "aws_dbe_b_location"
               KeyType: "HASH"
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            ReadCapacityUnits: "5"
-            WriteCapacityUnits: "5"
         - IndexName: "stateAndHasSensitiveData-index"
           KeySchema:
             - AttributeName: "aws_dbe_b_stateAndHasSensitiveData"
               KeyType: "HASH"
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            ReadCapacityUnits: "5"
-            WriteCapacityUnits: "5"
         - IndexName: "buildingAndFloor-index"
           KeySchema:
             - AttributeName: "aws_dbe_b_buildingAndFloor"
               KeyType: "HASH"
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            ReadCapacityUnits: "5"
-            WriteCapacityUnits: "5"
         - IndexName: "email-birthday-index"
           KeySchema:
             - AttributeName: "aws_dbe_b_email"
@@ -151,9 +137,6 @@ Resources:
               KeyType: "RANGE"
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            ReadCapacityUnits: "5"
-            WriteCapacityUnits: "5"
         - IndexName: "address-birthday-index"
           KeySchema:
             - AttributeName: "aws_dbe_b_address"
@@ -162,17 +145,12 @@ Resources:
               KeyType: "RANGE"
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            ReadCapacityUnits: "5"
-            WriteCapacityUnits: "5"
       KeySchema:
         - AttributeName: "customer_id"
           KeyType: "HASH"
         - AttributeName: "create_time"
           KeyType: "RANGE"
-      ProvisionedThroughput:
-        ReadCapacityUnits: "5"
-        WriteCapacityUnits: "5"
+      BillingMode: PAY_PER_REQUEST
       TableName: !Ref TableWithSimpleBeaconIndexName
 
   # This schema is modeled off of
@@ -207,9 +185,6 @@ Resources:
               KeyType: "RANGE"
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            ReadCapacityUnits: "5"
-            WriteCapacityUnits: "5"
         - IndexName: "GSI-1"
           KeySchema:
             - AttributeName: "aws_dbe_b_PK1"
@@ -218,18 +193,12 @@ Resources:
               KeyType: "RANGE"
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            ReadCapacityUnits: "5"
-            WriteCapacityUnits: "5"
         - IndexName: "GSI-2"
           KeySchema:
             - AttributeName: "aws_dbe_b_PK2"
               KeyType: "HASH"
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            ReadCapacityUnits: "5"
-            WriteCapacityUnits: "5"
         - IndexName: "GSI-3"
           KeySchema:
             - AttributeName: "aws_dbe_b_PK3"
@@ -238,15 +207,10 @@ Resources:
               KeyType: "RANGE"
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            ReadCapacityUnits: "5"
-            WriteCapacityUnits: "5"
       KeySchema:
         - AttributeName: "partition_key"
           KeyType: "HASH"
-      ProvisionedThroughput:
-        ReadCapacityUnits: "5"
-        WriteCapacityUnits: "5"
+      BillingMode: PAY_PER_REQUEST
       TableName: !Ref TableWithComplexBeaconIndexName
 
   TestKeystoreTable:
@@ -268,17 +232,12 @@ Resources:
               KeyType: "RANGE"
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            ReadCapacityUnits: "5"
-            WriteCapacityUnits: "5"
       KeySchema:
         - AttributeName: "branch-key-id"
           KeyType: "HASH"
         - AttributeName: "type"
           KeyType: "RANGE"
-      ProvisionedThroughput:
-        ReadCapacityUnits: "5"
-        WriteCapacityUnits: "5"
+      BillingMode: PAY_PER_REQUEST
       TableName: !Ref KeystoreTableName
 
   # This policy SHOULD be given to:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. .github/workflows/ci_test_vector_java.yml — Retry Docker image pull on macOS

The test vectors workflow uses Docker to run DynamoDB Local on macos-15-intel. Docker is installed via Colima, which 
has intermittent failures pulling container images (socket resets, layer corruption). Added an explicit docker pull 
step with 3 retries using nick-fields/retry@v3 before the rrainn/dynamodb-action runs. If the pull succeeds on any 
attempt, the action finds the image cached locally and skips the pull.

2. DynamoDbEncryptionInterceptorIntegrationTests.java — Fix TransactionConflict in parallel CI

TestTransactWriteAndGet used a hardcoded partition key "transact". When multiple CI matrix jobs (Java 8/11/17/19/21 × 
OS) run in parallel against the same DynamoDB table, concurrent transactWriteItems calls on the same item cause 
TransactionConflict. Fixed by appending the existing randomNum field (already used by other tests in this class for the
same reason) to the partition key.

3. cfn/CI.yaml — Switch CI tables to on-demand billing


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
