### PR TITLE
fix(java): drop hkdf offset method

### DIFF
--- a/DynamoDbEncryption/runtimes/java/src/main/sdkv2/com/amazonaws/services/dynamodbv2/datamodeling/sdkv2/internal/Hkdf.java
+++ b/DynamoDbEncryption/runtimes/java/src/main/sdkv2/com/amazonaws/services/dynamodbv2/datamodeling/sdkv2/internal/Hkdf.java
@@ -234,49 +234,9 @@ public final class Hkdf {
   public byte[] deriveKey(final byte[] info, final int length)
     throws IllegalStateException {
     byte[] result = new byte[length];
-    try {
-      deriveKey(info, length, result, 0);
-    } catch (ShortBufferException ex) {
-      // This exception is impossible as we ensure the buffer is long
-      // enough
-      throw new RuntimeException(ex);
-    }
-    return result;
-  }
 
-  /**
-   * Derives a pseudorandom key of <code>length</code> bytes and stores the
-   * result in <code>output</code>.
-   *
-   * @param info
-   *            optional context and application specific information (can be
-   *            a zero-length array).
-   * @param length
-   *            the length of the output key in bytes
-   * @param output
-   *            the buffer where the pseudorandom key will be stored
-   * @param offset
-   *            the offset in <code>output</code> where the key will be stored
-   * @throws ShortBufferException
-   *             if the given output buffer is too small to hold the result
-   * @throws IllegalStateException
-   *             if this object has not been initialized
-   */
-  public void deriveKey(
-    final byte[] info,
-    final int length,
-    final byte[] output,
-    final int offset
-  ) throws ShortBufferException, IllegalStateException {
     assertInitialized();
-    if (length < 0) {
-      throw new IllegalArgumentException(
-        "Length must be a non-negative value."
-      );
-    }
-    if (output.length < offset + length) {
-      throw new ShortBufferException();
-    }
+
     Mac mac = createMac();
 
     if (length > 255 * mac.getMacLength()) {
@@ -296,7 +256,7 @@ public final class Hkdf {
         t = mac.doFinal();
 
         for (int x = 0; x < t.length && loc < length; x++, loc++) {
-          output[loc] = t[x];
+          result[loc] = t[x];
         }
 
         i++;
@@ -304,6 +264,7 @@ public final class Hkdf {
     } finally {
       Arrays.fill(t, (byte) 0); // Zeroize temporary array
     }
+    return result;
   }
 
   private Mac createMac() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The offset in HKDF was never used. The bug is completely inert in practice — all in-tree callers use the 2-parameter deriveKey() overload which passes offset=0, making the incorrect initialization equivalent to the correct one. Same fix as DDBEC with SDK V1. See 

1. https://github.com/aws/aws-database-encryption-sdk-dynamodb/commit/b8f29f914d2c593de83304a186869aec12f020e3
2. https://github.com/aws/aws-dynamodb-encryption-java/commit/600e7357a032d3e33ea9d1edac24acf4f4de7a84



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
