### PR TITLE
chore(java): bring back test against released MPL version

### DIFF
--- a/.github/workflows/ci_test_latest_released_mpl_java.yml
+++ b/.github/workflows/ci_test_latest_released_mpl_java.yml
@@ -102,8 +102,8 @@ jobs:
         with:
           dafny-version: ${{ inputs.dafny }}
 
-      # - name: Install Smithy-Dafny codegen dependencies
-      #   uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
+      - name: Install Smithy-Dafny codegen dependencies
+        uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
 
       # - name: Regenerate code using smithy-dafny if necessary
       #   if: ${{ inputs.regenerate-code }}

--- a/.github/workflows/ci_test_latest_released_mpl_java.yml
+++ b/.github/workflows/ci_test_latest_released_mpl_java.yml
@@ -15,7 +15,8 @@ on:
         type: boolean
       mpl_version:
         description: "Latest released MPL version (e.g. 1.11.1). Overrides version in project.properties."
-        required: true
+        required: false
+        default: ""
         type: string
 
 permissions:
@@ -36,6 +37,8 @@ jobs:
     uses: ./.github/workflows/mpl_dependency_java_version.yml
   testJava:
     needs: [getVersion, getMplDependencyJavaVersion]
+    env:                                                                                                                                                                                        
+      MPL_VERSION: ${{ inputs.mpl_version || needs.getMplDependencyJavaVersion.outputs.version }}
     strategy:
       max-parallel: 1
       matrix:
@@ -81,9 +84,8 @@ jobs:
           update-and-regenerate-mpl: true
 
       - name: Override MPL dependency version
-        if: github.event_name == 'workflow_dispatch'
         run: |
-          sed -i "s/mplDependencyJavaVersion=.*/mplDependencyJavaVersion=${{ inputs.mpl_version }}/" project.properties
+          sed -i "s/mplDependencyJavaVersion=.*/mplDependencyJavaVersion=${{ env.MPL_VERSION }}/" project.properties
 
       # The following two steps: "Build and deploy to maven local" and "Run Extensive Tests"
       # mimic the tests in ./codebuild/staging/release-staging.yml
@@ -110,7 +112,7 @@ jobs:
       - name: Update project.properties to use the correct MPL version (from project.properties in DB-ESDK)
         working-directory: ./submodules/MaterialProviders/
         run: |
-          sed "s/javaMPLVersion=.*/javaMPLVersion=${{needs.getMplDependencyJavaVersion.outputs.version}}/g" project.properties > project.properties2; mv project.properties2 project.properties
+          sed "s/javaMPLVersion=.*/javaMPLVersion=${{env.MPL_VERSION}}/g" project.properties > project.properties2; mv project.properties2 project.properties
 
       # The following three steps: "Transpile MPL Test Vectors without recursively building the MPL",
       # "Run Test Vectors", and "Test Examples" mimic the tests in ./codebuild/staging/validate-staging.yml

--- a/.github/workflows/ci_test_latest_released_mpl_java.yml
+++ b/.github/workflows/ci_test_latest_released_mpl_java.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Update project.properties to use the correct MPL version (from project.properties in DB-ESDK)
         working-directory: ./submodules/MaterialProviders/
         run: |
-          sed "s/mplVersion=.*/mplVersion=${{needs.getMplDependencyJavaVersion.outputs.version}}/g" project.properties > project.properties2; mv project.properties2 project.properties
+          sed "s/javaMPLVersion=.*/javaMPLVersion=${{needs.getMplDependencyJavaVersion.outputs.version}}/g" project.properties > project.properties2; mv project.properties2 project.properties
 
       # The following three steps: "Transpile MPL Test Vectors without recursively building the MPL",
       # "Run Test Vectors", and "Test Examples" mimic the tests in ./codebuild/staging/validate-staging.yml

--- a/.github/workflows/ci_test_latest_released_mpl_java.yml
+++ b/.github/workflows/ci_test_latest_released_mpl_java.yml
@@ -1,0 +1,129 @@
+# This workflow is for testing that the latest released version
+# of the MPL is compatible with the current DB-ESDK Head
+name: Test Latest Released MPL Java with DB-ESDK HEAD
+
+on:
+  schedule:
+    - cron: "00 16 * * 1-5"
+  workflow_dispatch: # allows triggering this manually through the Actions UI
+    inputs:
+      run_test_vectors:
+        description: "Run Test Vectors?"
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  getVersion:
+    # Don't run the cron builds on forks
+    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
+    uses: ./.github/workflows/dafny_version.yml
+  getVerifyVersion:
+    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
+    uses: ./.github/workflows/dafny_verify_version.yml
+  getMplDependencyJavaVersion:
+    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
+    uses: ./.github/workflows/mpl_dependency_java_version.yml
+  testJava:
+    needs: [getVersion, getMplDependencyJavaVersion]
+    strategy:
+      max-parallel: 1
+      matrix:
+        java-version: [17]
+        os: [ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-region: us-west-2
+          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-DDBEC-Dafny-Role-us-west-2
+          role-session-name: DDBEC-Dafny-Java-Tests
+
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Setup Java ${{ matrix.java-version }}
+        uses: actions/setup-java@v5
+        with:
+          distribution: "corretto"
+          java-version: ${{ matrix.java-version }}
+
+      - name: Setup Dafny
+        uses: ./submodules/MaterialProviders/.github/actions/setup_dafny/
+        with:
+          dafny-version: ${{ needs.getVersion.outputs.version }}
+
+      - name: Install Smithy-Dafny codegen dependencies
+        uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
+
+      - name: Regenerate code using smithy-dafny if necessary
+        if: ${{ inputs.regenerate-code }}
+        uses: ./.github/actions/polymorph_codegen
+        with:
+          dafny: ${{ env.DAFNY_VERSION }}
+          library: DynamoDbEncryption
+          diff-generated-code: false
+          update-and-regenerate-mpl: true
+
+      # The following two steps: "Build and deploy to maven local" and "Run Extensive Tests"
+      # mimic the tests in ./codebuild/staging/release-staging.yml
+      - name: Build and deploy to maven local
+        shell: bash
+        working-directory: ./DynamoDbEncryption
+        run: |
+          # Run transpile by itself. We don't want to locally build the MPL because
+          # we want to verify that the version pulled down from maven works correctly
+          make transpile_implementation_java
+          make transpile_test_java
+          make mvn_local_deploy
+          make test_java
+
+      - name: Run Extensive Tests
+        working-directory: ./DynamoDbEncryption
+        run: |
+          gradle -p runtimes/java clean
+          gradle -p runtimes/java test
+
+      # This makes sure that we are using the correct MPL version to test the DB-ESDK.
+      # If this contains a SNAPSHOT version, this will fail because'
+      # we are NOT building the MPL recursively but pulling from Maven.
+      - name: Update project.properties to use the correct MPL version (from project.properties in DB-ESDK)
+        working-directory: ./submodules/MaterialProviders/
+        run: |
+          sed "s/mplVersion=.*/mplVersion=${{needs.getMplDependencyJavaVersion.outputs.version}}/g" project.properties > project.properties2; mv project.properties2 project.properties
+
+      # The following three steps: "Transpile MPL Test Vectors without recursively building the MPL",
+      # "Run Test Vectors", and "Test Examples" mimic the tests in ./codebuild/staging/validate-staging.yml
+      - name: Transpile MPL Test Vectors without recursively building the MPL
+        working-directory: ./submodules/MaterialProviders/TestVectorsAwsCryptographicMaterialProviders
+        run: |
+          # Run transpile by itself. We don't want to locally build the MPL because
+          # we want to verify that the version pulled down from maven works correctly
+          make transpile_implementation_java
+          make transpile_test_java
+          make mvn_local_deploy
+
+      - name: Run Test Vectors
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && ${{inputs.run_test_vectors}})
+        working-directory: ./TestVectors
+        run: |
+          # Spin up ddb local
+          docker run --name dynamodb -d -p 8000:8000 amazon/dynamodb-local -jar DynamoDBLocal.jar -port 8000 -inMemory -cors *
+          # Run transpile by itself so we don't locally build the MPL.
+          make transpile_implementation_java
+          make transpile_test_java
+          gradle -p runtimes/java runTests
+
+      - name: Test Examples
+        working-directory: ./Examples
+        run: |
+          # Run Simple Examples
+          gradle -p runtimes/java/DynamoDbEncryption test
+          # Run Migration Examples
+          gradle -p runtimes/java/Migration/PlaintextToAWSDBE test
+          gradle -p runtimes/java/Migration/DDBECToAWSDBE test

--- a/.github/workflows/ci_test_latest_released_mpl_java.yml
+++ b/.github/workflows/ci_test_latest_released_mpl_java.yml
@@ -67,7 +67,7 @@ jobs:
       strip_snapshot: ${{ inputs.strip_snapshot == true || github.event_name == 'schedule' }}
   testJava:
     needs: [getMplDependencyJavaVersion]
-    env:                                                                                                                                                                                        
+    env:
       MPL_VERSION: ${{ inputs.mpl_version || needs.getMplDependencyJavaVersion.outputs.version }}
     strategy:
       max-parallel: 1
@@ -102,17 +102,17 @@ jobs:
         with:
           dafny-version: ${{ inputs.dafny }}
 
-      - name: Install Smithy-Dafny codegen dependencies
-        uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
+      # - name: Install Smithy-Dafny codegen dependencies
+      #   uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
 
-      - name: Regenerate code using smithy-dafny if necessary
-        if: ${{ inputs.regenerate-code }}
-        uses: ./.github/actions/polymorph_codegen
-        with:
-          dafny: ${{ inputs.dafny }}
-          library: DynamoDbEncryption
-          diff-generated-code: false
-          update-and-regenerate-mpl: true
+      # - name: Regenerate code using smithy-dafny if necessary
+      #   if: ${{ inputs.regenerate-code }}
+      #   uses: ./.github/actions/polymorph_codegen
+      #   with:
+      #     dafny: ${{ inputs.dafny }}
+      #     library: DynamoDbEncryption
+      #     diff-generated-code: false
+      #     update-and-regenerate-mpl: true
 
       - name: Override MPL dependency version
         run: |
@@ -120,22 +120,22 @@ jobs:
 
       # The following two steps: "Build and deploy to maven local" and "Run Extensive Tests"
       # mimic the tests in ./codebuild/staging/release-staging.yml
-      - name: Build and deploy to maven local
-        shell: bash
-        working-directory: ./DynamoDbEncryption
-        run: |
-          # Run transpile by itself. We don't want to locally build the MPL because
-          # we want to verify that the version pulled down from maven works correctly
-          make transpile_implementation_java
-          make transpile_test_java
-          make mvn_local_deploy
-          make test_java
+      # - name: Build and deploy to maven local
+      #   shell: bash
+      #   working-directory: ./DynamoDbEncryption
+      #   run: |
+      #     # Run transpile by itself. We don't want to locally build the MPL because
+      #     # we want to verify that the version pulled down from maven works correctly
+      #     make transpile_implementation_java
+      #     make transpile_test_java
+      #     make mvn_local_deploy
+      #     make test_java
 
-      - name: Run Extensive Tests
-        working-directory: ./DynamoDbEncryption
-        run: |
-          gradle -p runtimes/java clean
-          gradle -p runtimes/java test
+      # - name: Run Extensive Tests
+      #   working-directory: ./DynamoDbEncryption
+      #   run: |
+      #     gradle -p runtimes/java clean
+      #     gradle -p runtimes/java test
 
       - name: Update project.properties to use the correct MPL version (from project.properties in DB-ESDK)
         working-directory: ./submodules/MaterialProviders/

--- a/.github/workflows/ci_test_latest_released_mpl_java.yml
+++ b/.github/workflows/ci_test_latest_released_mpl_java.yml
@@ -24,7 +24,7 @@ on:
         default: true
         type: boolean
       strip_snapshot:
-        description: "Strip -SNAPSHOT suffix from mplDependencyJavaVersion?"
+        description: "Strip -SNAPSHOT suffix from mpl Dependency in project properties?"
         required: false
         default: false
         type: boolean
@@ -49,7 +49,7 @@ on:
         default: true
         type: boolean
       strip_snapshot:
-        description: "Strip -SNAPSHOT suffix from mplDependencyJavaVersion?"
+        description: "Strip -SNAPSHOT suffix from mpl Dependency in project properties?"
         required: false
         default: false
         type: boolean
@@ -60,10 +60,10 @@ permissions:
 
 jobs:
   getMplDependencyJavaVersion:
-    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
+    if: github.repository_owner == 'aws'
     uses: ./.github/workflows/mpl_dependency_java_version.yml
     with:
-      strip_snapshot: ${{ inputs.strip_snapshot == true || github.event_name == 'schedule' }}
+      strip_snapshot: ${{ inputs.strip_snapshot == true }}
   testJava:
     needs: [getMplDependencyJavaVersion]
     strategy:

--- a/.github/workflows/ci_test_latest_released_mpl_java.yml
+++ b/.github/workflows/ci_test_latest_released_mpl_java.yml
@@ -163,8 +163,12 @@ jobs:
       - name: Test Examples
         working-directory: ./Examples
         run: |
-          # Run Simple Examples
-          gradle -p runtimes/java/DynamoDbEncryption test
-          # Run Migration Examples
-          gradle -p runtimes/java/Migration/PlaintextToAWSDBE test
-          gradle -p runtimes/java/Migration/DDBECToAWSDBE test
+          gradle -p runtimes/java/DynamoDbEncryption test 
+          if [[ "${{ inputs.branch }}" == "v3.x-Java" ]]; then                                                                                 
+            gradle -p runtimes/java/Migration/PlaintextToAWSDBE test                                                                           
+            gradle -p runtimes/java/Migration/DDBECToAWSDBE test                                                                               
+          else                                                                                                                                 
+            gradle -p runtimes/java/DDBECwithSDKV2 test                                                                                        
+            gradle -p runtimes/java/Migration/PlaintextToAWSDBE test                                                                           
+            gradle -p runtimes/java/Migration/DDBECv2ToAWSDBE test                                                                             
+          fi

--- a/.github/workflows/ci_test_latest_released_mpl_java.yml
+++ b/.github/workflows/ci_test_latest_released_mpl_java.yml
@@ -3,11 +3,46 @@
 name: Test Latest Released MPL Java with DB-ESDK HEAD
 
 on:
-  # Unless we update MPL's project properties, this cannot work on schedule
-  schedule:
-    - cron: "00 15 * * 1-5"
-  workflow_dispatch: # allows triggering this manually through the Actions UI
+  workflow_dispatch:
     inputs:
+      dafny:
+        description: "The Dafny version to run"
+        required: true
+        type: string
+      regenerate-code:
+        description: "Regenerate code using smithy-dafny"
+        required: false
+        default: false
+        type: boolean
+      branch:
+        description: "Branch to checkout"
+        required: true
+        type: string
+      run_test_vectors:
+        description: "Run Test Vectors?"
+        required: false
+        default: true
+        type: boolean
+      strip_snapshot:
+        description: "Strip -SNAPSHOT suffix from mplDependencyJavaVersion?"
+        required: false
+        default: false
+        type: boolean
+  workflow_call:
+    inputs:
+      dafny:
+        description: "The Dafny version to run"
+        required: true
+        type: string
+      regenerate-code:
+        description: "Regenerate code using smithy-dafny"
+        required: false
+        default: false
+        type: boolean
+      branch:
+        description: "Branch to checkout"
+        required: false
+        type: string
       run_test_vectors:
         description: "Run Test Vectors?"
         required: false
@@ -25,20 +60,13 @@ permissions:
   pull-requests: write
 
 jobs:
-  getVersion:
-    # Don't run the cron builds on forks
-    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
-    uses: ./.github/workflows/dafny_version.yml
-  getVerifyVersion:
-    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
-    uses: ./.github/workflows/dafny_verify_version.yml
   getMplDependencyJavaVersion:
     if: github.event_name != 'schedule' || github.repository_owner == 'aws'
     uses: ./.github/workflows/mpl_dependency_java_version.yml
     with:
       strip_snapshot: ${{ inputs.strip_snapshot == true || github.event_name == 'schedule' }}
   testJava:
-    needs: [getVersion, getMplDependencyJavaVersion]
+    needs: [getMplDependencyJavaVersion]
     env:                                                                                                                                                                                        
       MPL_VERSION: ${{ inputs.mpl_version || needs.getMplDependencyJavaVersion.outputs.version }}
     strategy:
@@ -58,8 +86,9 @@ jobs:
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-DDBEC-Dafny-Role-us-west-2
           role-session-name: DDBEC-Dafny-Java-Tests
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.branch }}
           submodules: recursive
 
       - name: Setup Java ${{ matrix.java-version }}
@@ -71,7 +100,7 @@ jobs:
       - name: Setup Dafny
         uses: ./submodules/MaterialProviders/.github/actions/setup_dafny/
         with:
-          dafny-version: ${{ needs.getVersion.outputs.version }}
+          dafny-version: ${{ inputs.dafny }}
 
       - name: Install Smithy-Dafny codegen dependencies
         uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
@@ -80,7 +109,7 @@ jobs:
         if: ${{ inputs.regenerate-code }}
         uses: ./.github/actions/polymorph_codegen
         with:
-          dafny: ${{ env.DAFNY_VERSION }}
+          dafny: ${{ inputs.dafny }}
           library: DynamoDbEncryption
           diff-generated-code: false
           update-and-regenerate-mpl: true
@@ -125,7 +154,7 @@ jobs:
           make mvn_local_deploy
 
       - name: Run Test Vectors
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && ${{inputs.run_test_vectors}})
+        if: github.event_name == 'workflow_dispatch' && inputs.run_test_vectors
         working-directory: ./TestVectors
         run: |
           # Spin up ddb local

--- a/.github/workflows/ci_test_latest_released_mpl_java.yml
+++ b/.github/workflows/ci_test_latest_released_mpl_java.yml
@@ -75,6 +75,10 @@ jobs:
           diff-generated-code: false
           update-and-regenerate-mpl: true
 
+      - name: Strip SNAPSHOT from MPL dependency version
+        run: |
+          sed -i 's/mplDependencyJavaVersion=\(.*\)-SNAPSHOT/mplDependencyJavaVersion=\1/' project.properties
+
       # The following two steps: "Build and deploy to maven local" and "Run Extensive Tests"
       # mimic the tests in ./codebuild/staging/release-staging.yml
       - name: Build and deploy to maven local

--- a/.github/workflows/ci_test_latest_released_mpl_java.yml
+++ b/.github/workflows/ci_test_latest_released_mpl_java.yml
@@ -13,6 +13,11 @@ on:
         default: true
         type: boolean
 
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
 jobs:
   getVersion:
     # Don't run the cron builds on forks

--- a/.github/workflows/ci_test_latest_released_mpl_java.yml
+++ b/.github/workflows/ci_test_latest_released_mpl_java.yml
@@ -4,8 +4,8 @@ name: Test Latest Released MPL Java with DB-ESDK HEAD
 
 on:
   # Unless we update MPL's project properties, this cannot work on schedule
-  # schedule:
-  #   - cron: "00 16 * * 1-5"
+  schedule:
+    - cron: "00 15 * * 1-5"
   workflow_dispatch: # allows triggering this manually through the Actions UI
     inputs:
       run_test_vectors:
@@ -13,11 +13,11 @@ on:
         required: false
         default: true
         type: boolean
-      mpl_version:
-        description: "Latest released MPL version (e.g. 1.11.1). Overrides version in project.properties."
+      strip_snapshot:
+        description: "Strip -SNAPSHOT suffix from mplDependencyJavaVersion?"
         required: false
-        default: ""
-        type: string
+        default: false
+        type: boolean
 
 permissions:
   id-token: write
@@ -35,6 +35,8 @@ jobs:
   getMplDependencyJavaVersion:
     if: github.event_name != 'schedule' || github.repository_owner == 'aws'
     uses: ./.github/workflows/mpl_dependency_java_version.yml
+    with:
+      strip_snapshot: ${{ inputs.strip_snapshot == true || github.event_name == 'schedule' }}
   testJava:
     needs: [getVersion, getMplDependencyJavaVersion]
     env:                                                                                                                                                                                        
@@ -85,7 +87,7 @@ jobs:
 
       - name: Override MPL dependency version
         run: |
-          sed -i "s/mplDependencyJavaVersion=.*/mplDependencyJavaVersion=${{ env.MPL_VERSION }}/" project.properties
+          sed -i "s/mplDependencyJavaVersion=.*/mplDependencyJavaVersion=${{ needs.getMplDependencyJavaVersion.outputs.version }}/" project.properties
 
       # The following two steps: "Build and deploy to maven local" and "Run Extensive Tests"
       # mimic the tests in ./codebuild/staging/release-staging.yml
@@ -106,13 +108,10 @@ jobs:
           gradle -p runtimes/java clean
           gradle -p runtimes/java test
 
-      # This makes sure that we are using the correct MPL version to test the DB-ESDK.
-      # If this contains a SNAPSHOT version, this will fail because'
-      # we are NOT building the MPL recursively but pulling from Maven.
       - name: Update project.properties to use the correct MPL version (from project.properties in DB-ESDK)
         working-directory: ./submodules/MaterialProviders/
         run: |
-          sed "s/javaMPLVersion=.*/javaMPLVersion=${{env.MPL_VERSION}}/g" project.properties > project.properties2; mv project.properties2 project.properties
+          sed "s/javaMPLVersion=.*/javaMPLVersion=${{needs.getMplDependencyJavaVersion.outputs.version}}/g" project.properties > project.properties2; mv project.properties2 project.properties
 
       # The following three steps: "Transpile MPL Test Vectors without recursively building the MPL",
       # "Run Test Vectors", and "Test Examples" mimic the tests in ./codebuild/staging/validate-staging.yml

--- a/.github/workflows/ci_test_latest_released_mpl_java.yml
+++ b/.github/workflows/ci_test_latest_released_mpl_java.yml
@@ -57,6 +57,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  pull-requests: write
 
 jobs:
   getMplDependencyJavaVersion:

--- a/.github/workflows/ci_test_latest_released_mpl_java.yml
+++ b/.github/workflows/ci_test_latest_released_mpl_java.yml
@@ -57,7 +57,6 @@ on:
 permissions:
   id-token: write
   contents: read
-  pull-requests: write
 
 jobs:
   getMplDependencyJavaVersion:

--- a/.github/workflows/ci_test_latest_released_mpl_java.yml
+++ b/.github/workflows/ci_test_latest_released_mpl_java.yml
@@ -3,8 +3,9 @@
 name: Test Latest Released MPL Java with DB-ESDK HEAD
 
 on:
-  schedule:
-    - cron: "00 16 * * 1-5"
+  # Unless we update MPL's project properties, this cannot work on schedule
+  # schedule:
+  #   - cron: "00 16 * * 1-5"
   workflow_dispatch: # allows triggering this manually through the Actions UI
     inputs:
       run_test_vectors:
@@ -12,6 +13,10 @@ on:
         required: false
         default: true
         type: boolean
+      mpl_version:
+        description: "Latest released MPL version (e.g. 1.11.1). Overrides version in project.properties."
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -75,9 +80,10 @@ jobs:
           diff-generated-code: false
           update-and-regenerate-mpl: true
 
-      - name: Strip SNAPSHOT from MPL dependency version
+      - name: Override MPL dependency version
+        if: github.event_name == 'workflow_dispatch'
         run: |
-          sed -i 's/mplDependencyJavaVersion=\(.*\)-SNAPSHOT/mplDependencyJavaVersion=\1/' project.properties
+          sed -i "s/mplDependencyJavaVersion=.*/mplDependencyJavaVersion=${{ inputs.mpl_version }}/" project.properties
 
       # The following two steps: "Build and deploy to maven local" and "Run Extensive Tests"
       # mimic the tests in ./codebuild/staging/release-staging.yml

--- a/.github/workflows/ci_test_latest_released_mpl_java.yml
+++ b/.github/workflows/ci_test_latest_released_mpl_java.yml
@@ -41,7 +41,7 @@ on:
         type: boolean
       branch:
         description: "Branch to checkout"
-        required: false
+        required: true
         type: string
       run_test_vectors:
         description: "Run Test Vectors?"
@@ -150,7 +150,7 @@ jobs:
           make mvn_local_deploy
 
       - name: Run Test Vectors
-        if: github.event_name == 'workflow_dispatch' && inputs.run_test_vectors
+        if: inputs.run_test_vectors
         working-directory: ./TestVectors
         run: |
           # Spin up ddb local

--- a/.github/workflows/ci_test_latest_released_mpl_java.yml
+++ b/.github/workflows/ci_test_latest_released_mpl_java.yml
@@ -67,10 +67,7 @@ jobs:
       strip_snapshot: ${{ inputs.strip_snapshot == true || github.event_name == 'schedule' }}
   testJava:
     needs: [getMplDependencyJavaVersion]
-    env:
-      MPL_VERSION: ${{ inputs.mpl_version || needs.getMplDependencyJavaVersion.outputs.version }}
     strategy:
-      max-parallel: 1
       matrix:
         java-version: [17]
         os: [ubuntu-22.04]
@@ -105,14 +102,14 @@ jobs:
       - name: Install Smithy-Dafny codegen dependencies
         uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
 
-      # - name: Regenerate code using smithy-dafny if necessary
-      #   if: ${{ inputs.regenerate-code }}
-      #   uses: ./.github/actions/polymorph_codegen
-      #   with:
-      #     dafny: ${{ inputs.dafny }}
-      #     library: DynamoDbEncryption
-      #     diff-generated-code: false
-      #     update-and-regenerate-mpl: true
+      - name: Regenerate code using smithy-dafny if necessary
+        if: ${{ inputs.regenerate-code }}
+        uses: ./.github/actions/polymorph_codegen
+        with:
+          dafny: ${{ inputs.dafny }}
+          library: DynamoDbEncryption
+          diff-generated-code: false
+          update-and-regenerate-mpl: true
 
       - name: Override MPL dependency version
         run: |
@@ -120,22 +117,22 @@ jobs:
 
       # The following two steps: "Build and deploy to maven local" and "Run Extensive Tests"
       # mimic the tests in ./codebuild/staging/release-staging.yml
-      # - name: Build and deploy to maven local
-      #   shell: bash
-      #   working-directory: ./DynamoDbEncryption
-      #   run: |
-      #     # Run transpile by itself. We don't want to locally build the MPL because
-      #     # we want to verify that the version pulled down from maven works correctly
-      #     make transpile_implementation_java
-      #     make transpile_test_java
-      #     make mvn_local_deploy
-      #     make test_java
+      - name: Build and deploy to maven local
+        shell: bash
+        working-directory: ./DynamoDbEncryption
+        run: |
+          # Run transpile by itself. We don't want to locally build the MPL because
+          # we want to verify that the version pulled down from maven works correctly
+          make transpile_implementation_java
+          make transpile_test_java
+          make mvn_local_deploy
+          make test_java
 
-      # - name: Run Extensive Tests
-      #   working-directory: ./DynamoDbEncryption
-      #   run: |
-      #     gradle -p runtimes/java clean
-      #     gradle -p runtimes/java test
+      - name: Run Extensive Tests
+        working-directory: ./DynamoDbEncryption
+        run: |
+          gradle -p runtimes/java clean
+          gradle -p runtimes/java test
 
       - name: Update project.properties to use the correct MPL version (from project.properties in DB-ESDK)
         working-directory: ./submodules/MaterialProviders/

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -193,6 +193,7 @@ jobs:
     uses: ./.github/workflows/ci_test_latest_released_mpl_java.yml
     with:
       dafny: ${{needs.getVersion.outputs.version}}
+      branch: ${{ matrix.branch }}
       run_test_vectors: true
       strip_snapshot: true
 

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -182,6 +182,17 @@ jobs:
     with:
       dafny: ${{needs.getVersion.outputs.version}}
       branch: ${{ matrix.branch }}
+  test-with-released-mpl:
+    needs: getVersion
+    strategy:
+      matrix:
+        branch: [main, v3.x-Java]
+    uses: ./.github/workflows/ci_test_latest_released_mpl_java.yml
+    with:
+      dafny: ${{needs.getVersion.outputs.version}}
+      run_test_vectors: true
+      strip_snapshot: true
+
   notify:
     permissions:
       contents: read

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -182,7 +182,10 @@ jobs:
     with:
       dafny: ${{needs.getVersion.outputs.version}}
       branch: ${{ matrix.branch }}
-  test-with-released-mpl:
+  daily-test-with-released-mpl:
+    permissions:
+      id-token: write
+      contents: read
     needs: getVersion
     strategy:
       matrix:
@@ -213,6 +216,7 @@ jobs:
         daily-ci-rust,
         daily-ci-net-test-vectors,
         daily-ci-net-examples,
+        daily-test-with-released-mpl,
       ]
     if: ${{ failure() && github.event_name == 'schedule'}}
     uses: aws/aws-cryptographic-material-providers-library/.github/workflows/slack-notification.yml@main

--- a/.github/workflows/mpl_dependency_java_version.yml
+++ b/.github/workflows/mpl_dependency_java_version.yml
@@ -20,7 +20,6 @@ jobs:
   getMplDependencyJavaVersion:
     permissions:
       contents: read
-      pull-requests: write
       id-token: write
     runs-on: ubuntu-22.04
     outputs:

--- a/.github/workflows/mpl_dependency_java_version.yml
+++ b/.github/workflows/mpl_dependency_java_version.yml
@@ -5,6 +5,12 @@ name: MPL Dependency Java Version
 
 on:
   workflow_call:
+    inputs:
+      strip_snapshot:
+        description: "Strip -SNAPSHOT suffix from version"
+        required: false
+        default: false
+        type: boolean
     outputs:
       version:
         description: "The MPL Dependency Java version from project.properties"
@@ -18,7 +24,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-22.04
     outputs:
-      version: ${{ steps.read_property.outputs.mplDependencyJavaVersion }}
+      version: ${{ steps.resolve_version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
       - name: Read version from Properties-file
@@ -27,3 +33,11 @@ jobs:
         with:
           path: "./project.properties"
           properties: "mplDependencyJavaVersion"
+      - name: Resolve version
+        id: resolve_version
+        run: |
+          VERSION="${{ steps.read_property.outputs.mplDependencyJavaVersion }}"
+          if [ "${{ inputs.strip_snapshot }}" == "true" ]; then
+            VERSION="${VERSION%-SNAPSHOT}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/mpl_dependency_java_version.yml
+++ b/.github/workflows/mpl_dependency_java_version.yml
@@ -34,9 +34,12 @@ jobs:
           properties: "mplDependencyJavaVersion"
       - name: Resolve version
         id: resolve_version
+        env:                                                                                                                                                                                     
+          RAW_VERSION: ${{ steps.read_property.outputs.mplDependencyJavaVersion }}                                                                                                               
+          STRIP: ${{ inputs.strip_snapshot }}
         run: |
-          VERSION="${{ steps.read_property.outputs.mplDependencyJavaVersion }}"
-          if [ "${{ inputs.strip_snapshot }}" == "true" ]; then
-            VERSION="${VERSION%-SNAPSHOT}"
-          fi
+          VERSION="$RAW_VERSION"
+          if [ "$STRIP" == "true" ]; then                                                                                                                                                        
+            VERSION="${VERSION%-SNAPSHOT}"                                                                                                                                                       
+          fi                                                                                                                                                                                     
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/mpl_dependency_java_version.yml
+++ b/.github/workflows/mpl_dependency_java_version.yml
@@ -34,8 +34,8 @@ jobs:
           properties: "mplDependencyJavaVersion"
       - name: Resolve version
         id: resolve_version
-        env:                                                                                                                                                                                     
-          RAW_VERSION: ${{ steps.read_property.outputs.mplDependencyJavaVersion }}                                                                                                               
+        env:
+          RAW_VERSION: ${{ steps.read_property.outputs.mplDependencyJavaVersion }}
           STRIP: ${{ inputs.strip_snapshot }}
         run: |
           VERSION="$RAW_VERSION"

--- a/DynamoDbEncryption/dafny/DynamoDbEncryption/src/DynamoToStruct.dfy
+++ b/DynamoDbEncryption/dafny/DynamoDbEncryption/src/DynamoToStruct.dfy
@@ -40,7 +40,7 @@ module DynamoToStruct {
   }
   by method {
     var attrNames : seq<AttributeName> := SortedSets.ComputeSetToSequence(item.Keys);
-    var m := new DafnyLibraries.MutableMap<AttributeName, StructuredDataTerminal>();
+    var m := new DafnyLibraries.MutableMap<AttributeName, StructuredDataTerminal>((k: AttributeName, v: StructuredDataTerminal) => true, false);
     SequenceIsSafeBecauseItIsInMemory(attrNames);
     for i : uint64 := 0 to |attrNames| as uint64 {
       var k := attrNames[i];
@@ -125,7 +125,7 @@ module DynamoToStruct {
   }
   by method {
     var attrNames : seq<AttributeName> := SortedSets.ComputeSetToSequence(orig.Keys);
-    var m := new DafnyLibraries.MutableMap<AttributeName, AttributeValue>();
+    var m := new DafnyLibraries.MutableMap<AttributeName, AttributeValue>((k: AttributeName, v: AttributeValue) => true, false);
     SequenceIsSafeBecauseItIsInMemory(attrNames);
     for i : uint64 := 0 to |attrNames| as uint64 {
       var k := attrNames[i];

--- a/DynamoDbEncryption/dafny/DynamoDbEncryption/src/DynamoToStruct.dfy
+++ b/DynamoDbEncryption/dafny/DynamoDbEncryption/src/DynamoToStruct.dfy
@@ -40,7 +40,7 @@ module DynamoToStruct {
   }
   by method {
     var attrNames : seq<AttributeName> := SortedSets.ComputeSetToSequence(item.Keys);
-    var m := new DafnyLibraries.MutableMap<AttributeName, StructuredDataTerminal>((k: AttributeName, v: StructuredDataTerminal) => true, false);
+    var m := new DafnyLibraries.MutableMap<AttributeName, StructuredDataTerminal>();
     SequenceIsSafeBecauseItIsInMemory(attrNames);
     for i : uint64 := 0 to |attrNames| as uint64 {
       var k := attrNames[i];
@@ -125,7 +125,7 @@ module DynamoToStruct {
   }
   by method {
     var attrNames : seq<AttributeName> := SortedSets.ComputeSetToSequence(orig.Keys);
-    var m := new DafnyLibraries.MutableMap<AttributeName, AttributeValue>((k: AttributeName, v: AttributeValue) => true, false);
+    var m := new DafnyLibraries.MutableMap<AttributeName, AttributeValue>();
     SequenceIsSafeBecauseItIsInMemory(attrNames);
     for i : uint64 := 0 to |attrNames| as uint64 {
       var k := attrNames[i];

--- a/project.properties
+++ b/project.properties
@@ -1,5 +1,5 @@
 projectJavaVersion=3.9.1-SNAPSHOT
-mplDependencyJavaVersion=1.11.2-SNAPSHOT
+mplDependencyJavaVersion=1.11.1-SNAPSHOT
 mplDependencyNetVersion=2.0.0
 dafnyVersion=4.9.0
 dafnyVerifyVersion=4.9.1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- This reverts commit 728158e and fixes `ci_test_latest_released_mpl_java.yml`. 
- Makes daily ci run with `ci_test_latest_released_mpl_java.yml`

Tested by running https://github.com/aws/aws-database-encryption-sdk-dynamodb/actions/runs/25077953868/job/73475588150

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
