### PR TITLE
chore: update check-files.yml and bump mpl 

### DIFF
--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       # unfortunately we can't check if the approver is part of the CODEOWNERS. This is a subset of aws/aws-crypto-tools-team
       # to add more allowlisted approvers just modify this env variable
-      maintainers: seebees, texastony, ShubhamChaturvedi7, lucasmcdonald3, josecorella, rishav-karanjit, antonf-amzn, kessplas
+      maintainers: ShubhamChaturvedi7, lucasmcdonald3, josecorella, rishav-karanjit, antonf-amzn, kessplas, sharmabikram
     steps:
       - uses: actions/checkout@v6
         with:
@@ -28,7 +28,7 @@ jobs:
           # we require multiple approvers if any of those files change
           # when adding any release file, it must be appended with *release
           # we also want to check if there are changes to this file
-          echo "FILES=$(git diff --name-only origin/main origin/${GITHUB_HEAD_REF} .github/workflows/*release.yml .github/workflows/check-files.yml | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+          echo "FILES=$(git diff --name-only origin/v3.x-Java origin/${GITHUB_HEAD_REF} .github/workflows/*release.yml .github/workflows/check-files.yml | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
 
       - name: Check if FILES is not empty
         id: comment


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Updating check file's list of maintainers and for it to check `v3.x-java` instead of main because thats the default branch for v3.x java version
- I made changes so that installation of smithy-dafny deps will use workflow in MPL. I have bumped MPL in `main` but did not bumped MPL in `v3.x-java` branch. MPL needs to be bumped because get the new changes so that it can use the new process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
