### PR TITLE
Add TestVectorModels: native Java data classes for test vector harness

### DIFF
--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/TestVectorModels.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/TestVectorModels.java
@@ -1,0 +1,190 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.cryptography.dbencryptionsdk.dynamodb.testvectors;
+
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.cryptography.dbencryptionsdk.dynamodb.model.DynamoDbTableEncryptionConfig;
+
+/**
+ * Pure data classes used throughout the test vector harness.
+ * These replace the Dafny-generated datatypes from JsonConfig_Compile.
+ */
+public final class TestVectorModels {
+
+  public static final String TABLE_NAME = "GazelleVectorTable";
+  public static final String HASH_NAME = "RecNum";
+
+  private TestVectorModels() {}
+
+  public static final class Record {
+    public final int number;
+    public final Map<String, AttributeValue> item;
+
+    public Record(int number, Map<String, AttributeValue> item) {
+      this.number = number;
+      this.item = item;
+    }
+  }
+
+  public static final class LargeRecord {
+    public final String name;
+    public final Map<String, AttributeValue> item;
+
+    public LargeRecord(String name, Map<String, AttributeValue> item) {
+      this.name = name;
+      this.item = item;
+    }
+  }
+
+  public static final class TableConfig {
+    public final String name;
+    public final DynamoDbTableEncryptionConfig config;
+    public final boolean vanilla;
+
+    public TableConfig(
+      String name,
+      DynamoDbTableEncryptionConfig config,
+      boolean vanilla
+    ) {
+      this.name = name;
+      this.config = config;
+      this.vanilla = vanilla;
+    }
+  }
+
+  public static final class SimpleQuery {
+    public final String index;       // nullable
+    public final String keyExpr;     // nullable
+    public final String filterExpr;  // nullable
+    public final List<String> failConfigs;
+
+    public SimpleQuery(
+      String index,
+      String keyExpr,
+      String filterExpr,
+      List<String> failConfigs
+    ) {
+      this.index = index;
+      this.keyExpr = keyExpr;
+      this.filterExpr = filterExpr;
+      this.failConfigs = failConfigs;
+    }
+  }
+
+  public static final class ComplexQuery {
+    public final SimpleQuery query;
+    public final List<String> pass;
+    public final List<String> fail;
+
+    public ComplexQuery(
+      SimpleQuery query,
+      List<String> pass,
+      List<String> fail
+    ) {
+      this.query = query;
+      this.pass = pass;
+      this.fail = fail;
+    }
+  }
+
+  public static final class ComplexTest {
+    public final String config;
+    public final List<ComplexQuery> queries;
+    public final List<SimpleQuery> failures;
+
+    public ComplexTest(
+      String config,
+      List<ComplexQuery> queries,
+      List<SimpleQuery> failures
+    ) {
+      this.config = config;
+      this.queries = queries;
+      this.failures = failures;
+    }
+  }
+
+  public static final class RoundTripTest {
+    public final Map<String, TableConfig> configs;
+    public final List<Record> records;
+
+    public RoundTripTest(
+      Map<String, TableConfig> configs,
+      List<Record> records
+    ) {
+      this.configs = configs;
+      this.records = records;
+    }
+  }
+
+  public static final class WriteTest {
+    public final TableConfig config;
+    public final List<Record> records;
+    public final String fileName;
+
+    public WriteTest(
+      TableConfig config,
+      List<Record> records,
+      String fileName
+    ) {
+      this.config = config;
+      this.records = records;
+      this.fileName = fileName;
+    }
+  }
+
+  public static final class DecryptTest {
+    public final TableConfig config;
+    public final List<Record> encryptedRecords;
+    public final List<Record> plaintextRecords;
+
+    public DecryptTest(
+      TableConfig config,
+      List<Record> encryptedRecords,
+      List<Record> plaintextRecords
+    ) {
+      this.config = config;
+      this.encryptedRecords = encryptedRecords;
+      this.plaintextRecords = plaintextRecords;
+    }
+  }
+
+  public static final class IoTest {
+    public final String name;
+    public final TableConfig writeConfig;
+    public final TableConfig readConfig;
+    public final List<Record> records;
+    public final Map<String, String> names;
+    public final Map<String, AttributeValue> values;
+    public final List<SimpleQuery> queries;
+
+    public IoTest(
+      String name,
+      TableConfig writeConfig,
+      TableConfig readConfig,
+      List<Record> records,
+      Map<String, String> names,
+      Map<String, AttributeValue> values,
+      List<SimpleQuery> queries
+    ) {
+      this.name = name;
+      this.writeConfig = writeConfig;
+      this.readConfig = readConfig;
+      this.records = records;
+      this.names = names;
+      this.values = values;
+      this.queries = queries;
+    }
+  }
+
+  public static final class ConfigPair {
+    public final String first;
+    public final String second;
+
+    public ConfigPair(String first, String second) {
+      this.first = first;
+      this.second = second;
+    }
+  }
+}

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/TestVectorModels.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/TestVectorModels.java
@@ -1,0 +1,238 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.cryptography.dbencryptionsdk.dynamodb.testvectors;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.cryptography.dbencryptionsdk.dynamodb.model.DynamoDbTableEncryptionConfig;
+
+/**
+ * Replacement for Dafny-generated test vector model types.
+ * All collections are defensively copied to unmodifiable forms.
+ */
+public final class TestVectorModels {
+
+  public static final String TABLE_NAME = "GazelleVectorTable";
+  public static final String HASH_NAME = "RecNum";
+
+  private TestVectorModels() {}
+
+  public static final class Record {
+    public final int number;
+    public final Map<String, AttributeValue> item;
+
+    public Record(int number, Map<String, AttributeValue> item) {
+      this.number = number;
+      this.item = unmodifiableMap(Objects.requireNonNull(item, "item"));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof Record)) return false;
+      Record r = (Record) o;
+      return number == r.number && item.equals(r.item);
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * number + item.hashCode();
+    }
+  }
+
+  public static final class LargeRecord {
+    public final String name;
+    public final Map<String, AttributeValue> item;
+
+    public LargeRecord(String name, Map<String, AttributeValue> item) {
+      this.name = Objects.requireNonNull(name, "name");
+      this.item = unmodifiableMap(Objects.requireNonNull(item, "item"));
+    }
+  }
+
+  public static final class TableConfig {
+    public final String name;
+    public final DynamoDbTableEncryptionConfig config; // null when vanilla == true
+    public final boolean vanilla;
+
+    public TableConfig(
+      String name,
+      DynamoDbTableEncryptionConfig config,
+      boolean vanilla
+    ) {
+      this.name = Objects.requireNonNull(name, "name");
+      this.config = config;
+      this.vanilla = vanilla;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof TableConfig)) return false;
+      TableConfig t = (TableConfig) o;
+      return vanilla == t.vanilla
+        && name.equals(t.name)
+        && Objects.equals(config, t.config);
+    }
+
+    @Override
+    public int hashCode() {
+      int h = name.hashCode();
+      h = 31 * h + (config != null ? config.hashCode() : 0);
+      h = 31 * h + Boolean.hashCode(vanilla);
+      return h;
+    }
+  }
+
+  public static final class SimpleQuery {
+    public final String index;       // nullable
+    public final String keyExpr;     // nullable
+    public final String filterExpr;  // nullable
+    public final List<String> failConfigs;
+
+    public SimpleQuery(
+      String index,
+      String keyExpr,
+      String filterExpr,
+      List<String> failConfigs
+    ) {
+      this.index = index;
+      this.keyExpr = keyExpr;
+      this.filterExpr = filterExpr;
+      this.failConfigs = unmodifiableList(
+        Objects.requireNonNull(failConfigs, "failConfigs"));
+    }
+  }
+
+  public static final class ComplexQuery {
+    public final SimpleQuery query;
+    public final List<String> pass;
+    public final List<String> fail;
+
+    public ComplexQuery(
+      SimpleQuery query,
+      List<String> pass,
+      List<String> fail
+    ) {
+      this.query = Objects.requireNonNull(query, "query");
+      this.pass = unmodifiableList(Objects.requireNonNull(pass, "pass"));
+      this.fail = unmodifiableList(Objects.requireNonNull(fail, "fail"));
+    }
+  }
+
+  public static final class ComplexTest {
+    public final String config;
+    public final List<ComplexQuery> queries;
+    public final List<SimpleQuery> failures;
+
+    public ComplexTest(
+      String config,
+      List<ComplexQuery> queries,
+      List<SimpleQuery> failures
+    ) {
+      this.config = Objects.requireNonNull(config, "config");
+      this.queries = unmodifiableList(Objects.requireNonNull(queries, "queries"));
+      this.failures = unmodifiableList(Objects.requireNonNull(failures, "failures"));
+    }
+  }
+
+  public static final class RoundTripTest {
+    public final Map<String, TableConfig> configs;
+    public final List<Record> records;
+
+    public RoundTripTest(
+      Map<String, TableConfig> configs,
+      List<Record> records
+    ) {
+      this.configs = unmodifiableMap(Objects.requireNonNull(configs, "configs"));
+      this.records = unmodifiableList(Objects.requireNonNull(records, "records"));
+    }
+  }
+
+  public static final class WriteTest {
+    public final TableConfig config;
+    public final List<Record> records;
+    public final String fileName;
+
+    public WriteTest(
+      TableConfig config,
+      List<Record> records,
+      String fileName
+    ) {
+      this.config = Objects.requireNonNull(config, "config");
+      this.records = unmodifiableList(Objects.requireNonNull(records, "records"));
+      this.fileName = Objects.requireNonNull(fileName, "fileName");
+    }
+  }
+
+  public static final class DecryptTest {
+    public final TableConfig config;
+    public final List<Record> encryptedRecords;
+    public final List<Record> plaintextRecords;
+
+    public DecryptTest(
+      TableConfig config,
+      List<Record> encryptedRecords,
+      List<Record> plaintextRecords
+    ) {
+      this.config = Objects.requireNonNull(config, "config");
+      this.encryptedRecords = unmodifiableList(
+        Objects.requireNonNull(encryptedRecords, "encryptedRecords"));
+      this.plaintextRecords = unmodifiableList(
+        Objects.requireNonNull(plaintextRecords, "plaintextRecords"));
+    }
+  }
+
+  public static final class IoTest {
+    public final String name;
+    public final TableConfig writeConfig;
+    public final TableConfig readConfig;
+    public final List<Record> records;
+    public final Map<String, String> names;
+    public final Map<String, AttributeValue> values;
+    public final List<SimpleQuery> queries;
+
+    public IoTest(
+      String name,
+      TableConfig writeConfig,
+      TableConfig readConfig,
+      List<Record> records,
+      Map<String, String> names,
+      Map<String, AttributeValue> values,
+      List<SimpleQuery> queries
+    ) {
+      this.name = Objects.requireNonNull(name, "name");
+      this.writeConfig = Objects.requireNonNull(writeConfig, "writeConfig");
+      this.readConfig = Objects.requireNonNull(readConfig, "readConfig");
+      this.records = unmodifiableList(Objects.requireNonNull(records, "records"));
+      this.names = unmodifiableMap(Objects.requireNonNull(names, "names"));
+      this.values = unmodifiableMap(Objects.requireNonNull(values, "values"));
+      this.queries = unmodifiableList(Objects.requireNonNull(queries, "queries"));
+    }
+  }
+
+  public static final class ConfigPair {
+    public final String first;
+    public final String second;
+
+    public ConfigPair(String first, String second) {
+      this.first = Objects.requireNonNull(first, "first");
+      this.second = Objects.requireNonNull(second, "second");
+    }
+  }
+
+  // Java 8 compatible defensive copy helpers
+
+  private static <T> List<T> unmodifiableList(List<T> src) {
+    return Collections.unmodifiableList(new ArrayList<>(src));
+  }
+
+  private static <K, V> Map<K, V> unmodifiableMap(Map<K, V> src) {
+    return Collections.unmodifiableMap(new HashMap<>(src));
+  }
+}

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/TestVectorModels.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/TestVectorModels.java
@@ -23,6 +23,7 @@ public final class TestVectorModels {
   private TestVectorModels() {}
 
   public static final class Record {
+
     public final int number;
     public final Map<String, AttributeValue> item;
 
@@ -46,6 +47,7 @@ public final class TestVectorModels {
   }
 
   public static final class LargeRecord {
+
     public final String name;
     public final Map<String, AttributeValue> item;
 
@@ -56,6 +58,7 @@ public final class TestVectorModels {
   }
 
   public static final class TableConfig {
+
     public final String name;
     public final DynamoDbTableEncryptionConfig config; // null when vanilla == true
     public final boolean vanilla;
@@ -75,9 +78,11 @@ public final class TestVectorModels {
       if (this == o) return true;
       if (!(o instanceof TableConfig)) return false;
       TableConfig t = (TableConfig) o;
-      return vanilla == t.vanilla
-        && name.equals(t.name)
-        && Objects.equals(config, t.config);
+      return (
+        vanilla == t.vanilla &&
+        name.equals(t.name) &&
+        Objects.equals(config, t.config)
+      );
     }
 
     @Override
@@ -90,9 +95,10 @@ public final class TestVectorModels {
   }
 
   public static final class SimpleQuery {
-    public final String index;       // nullable
-    public final String keyExpr;     // nullable
-    public final String filterExpr;  // nullable
+
+    public final String index; // nullable
+    public final String keyExpr; // nullable
+    public final String filterExpr; // nullable
     public final List<String> failConfigs;
 
     public SimpleQuery(
@@ -104,12 +110,13 @@ public final class TestVectorModels {
       this.index = index;
       this.keyExpr = keyExpr;
       this.filterExpr = filterExpr;
-      this.failConfigs = unmodifiableList(
-        Objects.requireNonNull(failConfigs, "failConfigs"));
+      this.failConfigs =
+        unmodifiableList(Objects.requireNonNull(failConfigs, "failConfigs"));
     }
   }
 
   public static final class ComplexQuery {
+
     public final SimpleQuery query;
     public final List<String> pass;
     public final List<String> fail;
@@ -126,6 +133,7 @@ public final class TestVectorModels {
   }
 
   public static final class ComplexTest {
+
     public final String config;
     public final List<ComplexQuery> queries;
     public final List<SimpleQuery> failures;
@@ -136,12 +144,15 @@ public final class TestVectorModels {
       List<SimpleQuery> failures
     ) {
       this.config = Objects.requireNonNull(config, "config");
-      this.queries = unmodifiableList(Objects.requireNonNull(queries, "queries"));
-      this.failures = unmodifiableList(Objects.requireNonNull(failures, "failures"));
+      this.queries =
+        unmodifiableList(Objects.requireNonNull(queries, "queries"));
+      this.failures =
+        unmodifiableList(Objects.requireNonNull(failures, "failures"));
     }
   }
 
   public static final class RoundTripTest {
+
     public final Map<String, TableConfig> configs;
     public final List<Record> records;
 
@@ -149,12 +160,15 @@ public final class TestVectorModels {
       Map<String, TableConfig> configs,
       List<Record> records
     ) {
-      this.configs = unmodifiableMap(Objects.requireNonNull(configs, "configs"));
-      this.records = unmodifiableList(Objects.requireNonNull(records, "records"));
+      this.configs =
+        unmodifiableMap(Objects.requireNonNull(configs, "configs"));
+      this.records =
+        unmodifiableList(Objects.requireNonNull(records, "records"));
     }
   }
 
   public static final class WriteTest {
+
     public final TableConfig config;
     public final List<Record> records;
     public final String fileName;
@@ -165,12 +179,14 @@ public final class TestVectorModels {
       String fileName
     ) {
       this.config = Objects.requireNonNull(config, "config");
-      this.records = unmodifiableList(Objects.requireNonNull(records, "records"));
+      this.records =
+        unmodifiableList(Objects.requireNonNull(records, "records"));
       this.fileName = Objects.requireNonNull(fileName, "fileName");
     }
   }
 
   public static final class DecryptTest {
+
     public final TableConfig config;
     public final List<Record> encryptedRecords;
     public final List<Record> plaintextRecords;
@@ -181,14 +197,19 @@ public final class TestVectorModels {
       List<Record> plaintextRecords
     ) {
       this.config = Objects.requireNonNull(config, "config");
-      this.encryptedRecords = unmodifiableList(
-        Objects.requireNonNull(encryptedRecords, "encryptedRecords"));
-      this.plaintextRecords = unmodifiableList(
-        Objects.requireNonNull(plaintextRecords, "plaintextRecords"));
+      this.encryptedRecords =
+        unmodifiableList(
+          Objects.requireNonNull(encryptedRecords, "encryptedRecords")
+        );
+      this.plaintextRecords =
+        unmodifiableList(
+          Objects.requireNonNull(plaintextRecords, "plaintextRecords")
+        );
     }
   }
 
   public static final class IoTest {
+
     public final String name;
     public final TableConfig writeConfig;
     public final TableConfig readConfig;
@@ -209,14 +230,17 @@ public final class TestVectorModels {
       this.name = Objects.requireNonNull(name, "name");
       this.writeConfig = Objects.requireNonNull(writeConfig, "writeConfig");
       this.readConfig = Objects.requireNonNull(readConfig, "readConfig");
-      this.records = unmodifiableList(Objects.requireNonNull(records, "records"));
+      this.records =
+        unmodifiableList(Objects.requireNonNull(records, "records"));
       this.names = unmodifiableMap(Objects.requireNonNull(names, "names"));
       this.values = unmodifiableMap(Objects.requireNonNull(values, "values"));
-      this.queries = unmodifiableList(Objects.requireNonNull(queries, "queries"));
+      this.queries =
+        unmodifiableList(Objects.requireNonNull(queries, "queries"));
     }
   }
 
   public static final class ConfigPair {
+
     public final String first;
     public final String second;
 

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/TestVectorModels.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/TestVectorModels.java
@@ -108,20 +108,12 @@ public final class TestVectorModels {
       this.index = index;
       this.keyExpr = keyExpr;
       this.filterExpr = filterExpr;
-<<<<<<< HEAD
       this.failConfigs =
         unmodifiableList(Objects.requireNonNull(failConfigs, "failConfigs"));
-=======
-      this.failConfigs = failConfigs;
->>>>>>> 0f315b8b47f667960aaf7fe67b3f11d6b29a5ce6
     }
   }
 
   public static final class ComplexQuery {
-<<<<<<< HEAD
-
-=======
->>>>>>> 0f315b8b47f667960aaf7fe67b3f11d6b29a5ce6
     public final SimpleQuery query;
     public final List<String> pass;
     public final List<String> fail;
@@ -188,10 +180,6 @@ public final class TestVectorModels {
   }
 
   public static final class DecryptTest {
-<<<<<<< HEAD
-
-=======
->>>>>>> 0f315b8b47f667960aaf7fe67b3f11d6b29a5ce6
     public final TableConfig config;
     public final List<Record> encryptedRecords;
     public final List<Record> plaintextRecords;


### PR DESCRIPTION
What: Replaces Dafny-generated datatypes from JsonConfig_Compile (Record, LargeRecord, TableConfig, SimpleQuery, ComplexQuery, ComplexTest, IoTest, WriteTest, DecryptTest, RoundTripTest, ConfigPair) with idiomatic Java.

Decisions:
- Used public final fields instead of getters (test harness code, not public API)
- Dafny Option<string> → nullable String (simpler for Java 8 target)
- Dafny seq<T> → List<T>, map<K,V> → Map<K,V>
- Dafny nat (BigInteger) → int for Record.number (test vectors won't exceed int range)
- Dafny ConfigName type alias → plain String
- Dafny tuple (ConfigName, ConfigName) → ConfigPair class
- DynamoDbTableEncryptionConfig references the native SDK model type directly
- AttributeValue uses AWS SDK v2 type (software.amazon.awssdk.services.dynamodb.model)
- Added TABLE_NAME and HASH_NAME constants (from Dafny source)

Not included: JSON parsing logic, factory methods, test runners (future PRs)

Verification: gradle compileJava passes (BUILD SUCCESSFUL)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
