### PR TITLE
chore: add data model classes for native Java test vector rewrite

### DIFF
--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/ComplexQuery.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/ComplexQuery.java
@@ -12,30 +12,38 @@ import java.util.List;
  */
 public class ComplexQuery {
 
-    private final SimpleQuery query;
-    private final List<String> pass;
-    private final List<String> fail;
+  private final SimpleQuery query;
+  private final List<String> pass;
+  private final List<String> fail;
 
-    public ComplexQuery(SimpleQuery query, List<String> pass, List<String> fail) {
-        this.query = query;
-        this.pass = pass != null ? Collections.unmodifiableList(pass) : Collections.<String>emptyList();
-        this.fail = fail != null ? Collections.unmodifiableList(fail) : Collections.<String>emptyList();
-    }
+  public ComplexQuery(SimpleQuery query, List<String> pass, List<String> fail) {
+    this.query = query;
+    this.pass =
+      pass != null
+        ? Collections.unmodifiableList(pass)
+        : Collections.<String>emptyList();
+    this.fail =
+      fail != null
+        ? Collections.unmodifiableList(fail)
+        : Collections.<String>emptyList();
+  }
 
-    public SimpleQuery getQuery() {
-        return query;
-    }
+  public SimpleQuery getQuery() {
+    return query;
+  }
 
-    public List<String> getPass() {
-        return pass;
-    }
+  public List<String> getPass() {
+    return pass;
+  }
 
-    public List<String> getFail() {
-        return fail;
-    }
+  public List<String> getFail() {
+    return fail;
+  }
 
-    @Override
-    public String toString() {
-        return "ComplexQuery{query=" + query + ", pass=" + pass + ", fail=" + fail + "}";
-    }
+  @Override
+  public String toString() {
+    return (
+      "ComplexQuery{query=" + query + ", pass=" + pass + ", fail=" + fail + "}"
+    );
+  }
 }

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/ComplexQuery.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/ComplexQuery.java
@@ -1,0 +1,41 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.cryptography.dbencryptionsdk.dynamodb.testvectors.model;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A complex query definition containing a simple query, a list of config names
+ * that should pass, and a list of config names that should fail.
+ */
+public class ComplexQuery {
+
+    private final SimpleQuery query;
+    private final List<String> pass;
+    private final List<String> fail;
+
+    public ComplexQuery(SimpleQuery query, List<String> pass, List<String> fail) {
+        this.query = query;
+        this.pass = pass != null ? Collections.unmodifiableList(pass) : Collections.<String>emptyList();
+        this.fail = fail != null ? Collections.unmodifiableList(fail) : Collections.<String>emptyList();
+    }
+
+    public SimpleQuery getQuery() {
+        return query;
+    }
+
+    public List<String> getPass() {
+        return pass;
+    }
+
+    public List<String> getFail() {
+        return fail;
+    }
+
+    @Override
+    public String toString() {
+        return "ComplexQuery{query=" + query + ", pass=" + pass + ", fail=" + fail + "}";
+    }
+}

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/ComplexTest.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/ComplexTest.java
@@ -12,30 +12,48 @@ import java.util.List;
  */
 public class ComplexTest {
 
-    private final String config;
-    private final List<ComplexQuery> queries;
-    private final List<SimpleQuery> failures;
+  private final String config;
+  private final List<ComplexQuery> queries;
+  private final List<SimpleQuery> failures;
 
-    public ComplexTest(String config, List<ComplexQuery> queries, List<SimpleQuery> failures) {
-        this.config = config;
-        this.queries = queries != null ? Collections.unmodifiableList(queries) : Collections.<ComplexQuery>emptyList();
-        this.failures = failures != null ? Collections.unmodifiableList(failures) : Collections.<SimpleQuery>emptyList();
-    }
+  public ComplexTest(
+    String config,
+    List<ComplexQuery> queries,
+    List<SimpleQuery> failures
+  ) {
+    this.config = config;
+    this.queries =
+      queries != null
+        ? Collections.unmodifiableList(queries)
+        : Collections.<ComplexQuery>emptyList();
+    this.failures =
+      failures != null
+        ? Collections.unmodifiableList(failures)
+        : Collections.<SimpleQuery>emptyList();
+  }
 
-    public String getConfig() {
-        return config;
-    }
+  public String getConfig() {
+    return config;
+  }
 
-    public List<ComplexQuery> getQueries() {
-        return queries;
-    }
+  public List<ComplexQuery> getQueries() {
+    return queries;
+  }
 
-    public List<SimpleQuery> getFailures() {
-        return failures;
-    }
+  public List<SimpleQuery> getFailures() {
+    return failures;
+  }
 
-    @Override
-    public String toString() {
-        return "ComplexTest{config='" + config + "', queries=" + queries + ", failures=" + failures + "}";
-    }
+  @Override
+  public String toString() {
+    return (
+      "ComplexTest{config='" +
+      config +
+      "', queries=" +
+      queries +
+      ", failures=" +
+      failures +
+      "}"
+    );
+  }
 }

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/ComplexTest.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/ComplexTest.java
@@ -1,0 +1,41 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.cryptography.dbencryptionsdk.dynamodb.testvectors.model;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A complex test definition containing a config name, a list of complex queries,
+ * and a list of failure queries.
+ */
+public class ComplexTest {
+
+    private final String config;
+    private final List<ComplexQuery> queries;
+    private final List<SimpleQuery> failures;
+
+    public ComplexTest(String config, List<ComplexQuery> queries, List<SimpleQuery> failures) {
+        this.config = config;
+        this.queries = queries != null ? Collections.unmodifiableList(queries) : Collections.<ComplexQuery>emptyList();
+        this.failures = failures != null ? Collections.unmodifiableList(failures) : Collections.<SimpleQuery>emptyList();
+    }
+
+    public String getConfig() {
+        return config;
+    }
+
+    public List<ComplexQuery> getQueries() {
+        return queries;
+    }
+
+    public List<SimpleQuery> getFailures() {
+        return failures;
+    }
+
+    @Override
+    public String toString() {
+        return "ComplexTest{config='" + config + "', queries=" + queries + ", failures=" + failures + "}";
+    }
+}

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/ConfigPair.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/ConfigPair.java
@@ -1,0 +1,31 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.cryptography.dbencryptionsdk.dynamodb.testvectors.model;
+
+/**
+ * A pair of config names (write config, read config) used for IO and modification tests.
+ */
+public class ConfigPair {
+
+  private final String writeConfig;
+  private final String readConfig;
+
+  public ConfigPair(String writeConfig, String readConfig) {
+    this.writeConfig = writeConfig;
+    this.readConfig = readConfig;
+  }
+
+  public String getWriteConfig() {
+    return writeConfig;
+  }
+
+  public String getReadConfig() {
+    return readConfig;
+  }
+
+  @Override
+  public String toString() {
+    return "ConfigPair{write='" + writeConfig + "', read='" + readConfig + "'}";
+  }
+}

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/DecryptTest.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/DecryptTest.java
@@ -11,35 +11,48 @@ import java.util.List;
  */
 public class DecryptTest {
 
-    private final TableConfig config;
-    private final List<Record> encryptedRecords;
-    private final List<Record> plaintextRecords;
+  private final TableConfig config;
+  private final List<Record> encryptedRecords;
+  private final List<Record> plaintextRecords;
 
-    public DecryptTest(TableConfig config, List<Record> encryptedRecords, List<Record> plaintextRecords) {
-        this.config = config;
-        this.encryptedRecords = encryptedRecords != null
-                ? Collections.unmodifiableList(encryptedRecords)
-                : Collections.<Record>emptyList();
-        this.plaintextRecords = plaintextRecords != null
-                ? Collections.unmodifiableList(plaintextRecords)
-                : Collections.<Record>emptyList();
-    }
+  public DecryptTest(
+    TableConfig config,
+    List<Record> encryptedRecords,
+    List<Record> plaintextRecords
+  ) {
+    this.config = config;
+    this.encryptedRecords =
+      encryptedRecords != null
+        ? Collections.unmodifiableList(encryptedRecords)
+        : Collections.<Record>emptyList();
+    this.plaintextRecords =
+      plaintextRecords != null
+        ? Collections.unmodifiableList(plaintextRecords)
+        : Collections.<Record>emptyList();
+  }
 
-    public TableConfig getConfig() {
-        return config;
-    }
+  public TableConfig getConfig() {
+    return config;
+  }
 
-    public List<Record> getEncryptedRecords() {
-        return encryptedRecords;
-    }
+  public List<Record> getEncryptedRecords() {
+    return encryptedRecords;
+  }
 
-    public List<Record> getPlaintextRecords() {
-        return plaintextRecords;
-    }
+  public List<Record> getPlaintextRecords() {
+    return plaintextRecords;
+  }
 
-    @Override
-    public String toString() {
-        return "DecryptTest{config=" + config + ", encryptedRecords=" + encryptedRecords.size()
-                + " items, plaintextRecords=" + plaintextRecords.size() + " items}";
-    }
+  @Override
+  public String toString() {
+    return (
+      "DecryptTest{config=" +
+      config +
+      ", encryptedRecords=" +
+      encryptedRecords.size() +
+      " items, plaintextRecords=" +
+      plaintextRecords.size() +
+      " items}"
+    );
+  }
 }

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/DecryptTest.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/DecryptTest.java
@@ -1,0 +1,45 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.cryptography.dbencryptionsdk.dynamodb.testvectors.model;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A decrypt test definition containing a config, encrypted records, and expected plaintext records.
+ */
+public class DecryptTest {
+
+    private final TableConfig config;
+    private final List<Record> encryptedRecords;
+    private final List<Record> plaintextRecords;
+
+    public DecryptTest(TableConfig config, List<Record> encryptedRecords, List<Record> plaintextRecords) {
+        this.config = config;
+        this.encryptedRecords = encryptedRecords != null
+                ? Collections.unmodifiableList(encryptedRecords)
+                : Collections.<Record>emptyList();
+        this.plaintextRecords = plaintextRecords != null
+                ? Collections.unmodifiableList(plaintextRecords)
+                : Collections.<Record>emptyList();
+    }
+
+    public TableConfig getConfig() {
+        return config;
+    }
+
+    public List<Record> getEncryptedRecords() {
+        return encryptedRecords;
+    }
+
+    public List<Record> getPlaintextRecords() {
+        return plaintextRecords;
+    }
+
+    @Override
+    public String toString() {
+        return "DecryptTest{config=" + config + ", encryptedRecords=" + encryptedRecords.size()
+                + " items, plaintextRecords=" + plaintextRecords.size() + " items}";
+    }
+}

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/IoTest.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/IoTest.java
@@ -13,57 +13,84 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
  */
 public class IoTest {
 
-    private final String name;
-    private final TableConfig writeConfig;
-    private final TableConfig readConfig;
-    private final List<Record> records;
-    private final Map<String, String> names;
-    private final Map<String, AttributeValue> values;
-    private final List<SimpleQuery> queries;
+  private final String name;
+  private final TableConfig writeConfig;
+  private final TableConfig readConfig;
+  private final List<Record> records;
+  private final Map<String, String> names;
+  private final Map<String, AttributeValue> values;
+  private final List<SimpleQuery> queries;
 
-    public IoTest(String name, TableConfig writeConfig, TableConfig readConfig,
-                  List<Record> records, Map<String, String> names,
-                  Map<String, AttributeValue> values, List<SimpleQuery> queries) {
-        this.name = name;
-        this.writeConfig = writeConfig;
-        this.readConfig = readConfig;
-        this.records = records != null ? Collections.unmodifiableList(records) : Collections.<Record>emptyList();
-        this.names = names != null ? Collections.unmodifiableMap(names) : Collections.<String, String>emptyMap();
-        this.values = values != null ? Collections.unmodifiableMap(values) : Collections.<String, AttributeValue>emptyMap();
-        this.queries = queries != null ? Collections.unmodifiableList(queries) : Collections.<SimpleQuery>emptyList();
-    }
+  public IoTest(
+    String name,
+    TableConfig writeConfig,
+    TableConfig readConfig,
+    List<Record> records,
+    Map<String, String> names,
+    Map<String, AttributeValue> values,
+    List<SimpleQuery> queries
+  ) {
+    this.name = name;
+    this.writeConfig = writeConfig;
+    this.readConfig = readConfig;
+    this.records =
+      records != null
+        ? Collections.unmodifiableList(records)
+        : Collections.<Record>emptyList();
+    this.names =
+      names != null
+        ? Collections.unmodifiableMap(names)
+        : Collections.<String, String>emptyMap();
+    this.values =
+      values != null
+        ? Collections.unmodifiableMap(values)
+        : Collections.<String, AttributeValue>emptyMap();
+    this.queries =
+      queries != null
+        ? Collections.unmodifiableList(queries)
+        : Collections.<SimpleQuery>emptyList();
+  }
 
-    public String getName() {
-        return name;
-    }
+  public String getName() {
+    return name;
+  }
 
-    public TableConfig getWriteConfig() {
-        return writeConfig;
-    }
+  public TableConfig getWriteConfig() {
+    return writeConfig;
+  }
 
-    public TableConfig getReadConfig() {
-        return readConfig;
-    }
+  public TableConfig getReadConfig() {
+    return readConfig;
+  }
 
-    public List<Record> getRecords() {
-        return records;
-    }
+  public List<Record> getRecords() {
+    return records;
+  }
 
-    public Map<String, String> getNames() {
-        return names;
-    }
+  public Map<String, String> getNames() {
+    return names;
+  }
 
-    public Map<String, AttributeValue> getValues() {
-        return values;
-    }
+  public Map<String, AttributeValue> getValues() {
+    return values;
+  }
 
-    public List<SimpleQuery> getQueries() {
-        return queries;
-    }
+  public List<SimpleQuery> getQueries() {
+    return queries;
+  }
 
-    @Override
-    public String toString() {
-        return "IoTest{name='" + name + "', writeConfig=" + writeConfig
-                + ", readConfig=" + readConfig + ", records=" + records.size() + " items}";
-    }
+  @Override
+  public String toString() {
+    return (
+      "IoTest{name='" +
+      name +
+      "', writeConfig=" +
+      writeConfig +
+      ", readConfig=" +
+      readConfig +
+      ", records=" +
+      records.size() +
+      " items}"
+    );
+  }
 }

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/IoTest.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/IoTest.java
@@ -1,0 +1,69 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.cryptography.dbencryptionsdk.dynamodb.testvectors.model;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * An IO test definition containing write/read configs, records, expression maps, and queries.
+ */
+public class IoTest {
+
+    private final String name;
+    private final TableConfig writeConfig;
+    private final TableConfig readConfig;
+    private final List<Record> records;
+    private final Map<String, String> names;
+    private final Map<String, AttributeValue> values;
+    private final List<SimpleQuery> queries;
+
+    public IoTest(String name, TableConfig writeConfig, TableConfig readConfig,
+                  List<Record> records, Map<String, String> names,
+                  Map<String, AttributeValue> values, List<SimpleQuery> queries) {
+        this.name = name;
+        this.writeConfig = writeConfig;
+        this.readConfig = readConfig;
+        this.records = records != null ? Collections.unmodifiableList(records) : Collections.<Record>emptyList();
+        this.names = names != null ? Collections.unmodifiableMap(names) : Collections.<String, String>emptyMap();
+        this.values = values != null ? Collections.unmodifiableMap(values) : Collections.<String, AttributeValue>emptyMap();
+        this.queries = queries != null ? Collections.unmodifiableList(queries) : Collections.<SimpleQuery>emptyList();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public TableConfig getWriteConfig() {
+        return writeConfig;
+    }
+
+    public TableConfig getReadConfig() {
+        return readConfig;
+    }
+
+    public List<Record> getRecords() {
+        return records;
+    }
+
+    public Map<String, String> getNames() {
+        return names;
+    }
+
+    public Map<String, AttributeValue> getValues() {
+        return values;
+    }
+
+    public List<SimpleQuery> getQueries() {
+        return queries;
+    }
+
+    @Override
+    public String toString() {
+        return "IoTest{name='" + name + "', writeConfig=" + writeConfig
+                + ", readConfig=" + readConfig + ", records=" + records.size() + " items}";
+    }
+}

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/LargeRecord.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/LargeRecord.java
@@ -11,24 +11,24 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
  */
 public class LargeRecord {
 
-    private final String name;
-    private final Map<String, AttributeValue> item;
+  private final String name;
+  private final Map<String, AttributeValue> item;
 
-    public LargeRecord(String name, Map<String, AttributeValue> item) {
-        this.name = name;
-        this.item = item;
-    }
+  public LargeRecord(String name, Map<String, AttributeValue> item) {
+    this.name = name;
+    this.item = item;
+  }
 
-    public String getName() {
-        return name;
-    }
+  public String getName() {
+    return name;
+  }
 
-    public Map<String, AttributeValue> getItem() {
-        return item;
-    }
+  public Map<String, AttributeValue> getItem() {
+    return item;
+  }
 
-    @Override
-    public String toString() {
-        return "LargeRecord{name='" + name + "', item=" + item + "}";
-    }
+  @Override
+  public String toString() {
+    return "LargeRecord{name='" + name + "', item=" + item + "}";
+  }
 }

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/LargeRecord.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/LargeRecord.java
@@ -1,0 +1,34 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.cryptography.dbencryptionsdk.dynamodb.testvectors.model;
+
+import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * A large test record consisting of a name and a DynamoDB item, used for performance testing.
+ */
+public class LargeRecord {
+
+    private final String name;
+    private final Map<String, AttributeValue> item;
+
+    public LargeRecord(String name, Map<String, AttributeValue> item) {
+        this.name = name;
+        this.item = item;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Map<String, AttributeValue> getItem() {
+        return item;
+    }
+
+    @Override
+    public String toString() {
+        return "LargeRecord{name='" + name + "', item=" + item + "}";
+    }
+}

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/Record.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/Record.java
@@ -11,24 +11,24 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
  */
 public class Record {
 
-    private final int number;
-    private final Map<String, AttributeValue> item;
+  private final int number;
+  private final Map<String, AttributeValue> item;
 
-    public Record(int number, Map<String, AttributeValue> item) {
-        this.number = number;
-        this.item = item;
-    }
+  public Record(int number, Map<String, AttributeValue> item) {
+    this.number = number;
+    this.item = item;
+  }
 
-    public int getNumber() {
-        return number;
-    }
+  public int getNumber() {
+    return number;
+  }
 
-    public Map<String, AttributeValue> getItem() {
-        return item;
-    }
+  public Map<String, AttributeValue> getItem() {
+    return item;
+  }
 
-    @Override
-    public String toString() {
-        return "Record{number=" + number + ", item=" + item + "}";
-    }
+  @Override
+  public String toString() {
+    return "Record{number=" + number + ", item=" + item + "}";
+  }
 }

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/Record.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/Record.java
@@ -1,0 +1,34 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.cryptography.dbencryptionsdk.dynamodb.testvectors.model;
+
+import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * A test record consisting of a record number and a DynamoDB item.
+ */
+public class Record {
+
+    private final int number;
+    private final Map<String, AttributeValue> item;
+
+    public Record(int number, Map<String, AttributeValue> item) {
+        this.number = number;
+        this.item = item;
+    }
+
+    public int getNumber() {
+        return number;
+    }
+
+    public Map<String, AttributeValue> getItem() {
+        return item;
+    }
+
+    @Override
+    public String toString() {
+        return "Record{number=" + number + ", item=" + item + "}";
+    }
+}

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/RoundTripTest.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/RoundTripTest.java
@@ -1,0 +1,36 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.cryptography.dbencryptionsdk.dynamodb.testvectors.model;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A round-trip test definition containing a map of configs and a list of records
+ * to encrypt then decrypt.
+ */
+public class RoundTripTest {
+
+    private final Map<String, TableConfig> configs;
+    private final List<Record> records;
+
+    public RoundTripTest(Map<String, TableConfig> configs, List<Record> records) {
+        this.configs = configs != null ? Collections.unmodifiableMap(configs) : Collections.<String, TableConfig>emptyMap();
+        this.records = records != null ? Collections.unmodifiableList(records) : Collections.<Record>emptyList();
+    }
+
+    public Map<String, TableConfig> getConfigs() {
+        return configs;
+    }
+
+    public List<Record> getRecords() {
+        return records;
+    }
+
+    @Override
+    public String toString() {
+        return "RoundTripTest{configs=" + configs.keySet() + ", records=" + records.size() + " items}";
+    }
+}

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/RoundTripTest.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/RoundTripTest.java
@@ -13,24 +13,36 @@ import java.util.Map;
  */
 public class RoundTripTest {
 
-    private final Map<String, TableConfig> configs;
-    private final List<Record> records;
+  private final Map<String, TableConfig> configs;
+  private final List<Record> records;
 
-    public RoundTripTest(Map<String, TableConfig> configs, List<Record> records) {
-        this.configs = configs != null ? Collections.unmodifiableMap(configs) : Collections.<String, TableConfig>emptyMap();
-        this.records = records != null ? Collections.unmodifiableList(records) : Collections.<Record>emptyList();
-    }
+  public RoundTripTest(Map<String, TableConfig> configs, List<Record> records) {
+    this.configs =
+      configs != null
+        ? Collections.unmodifiableMap(configs)
+        : Collections.<String, TableConfig>emptyMap();
+    this.records =
+      records != null
+        ? Collections.unmodifiableList(records)
+        : Collections.<Record>emptyList();
+  }
 
-    public Map<String, TableConfig> getConfigs() {
-        return configs;
-    }
+  public Map<String, TableConfig> getConfigs() {
+    return configs;
+  }
 
-    public List<Record> getRecords() {
-        return records;
-    }
+  public List<Record> getRecords() {
+    return records;
+  }
 
-    @Override
-    public String toString() {
-        return "RoundTripTest{configs=" + configs.keySet() + ", records=" + records.size() + " items}";
-    }
+  @Override
+  public String toString() {
+    return (
+      "RoundTripTest{configs=" +
+      configs.keySet() +
+      ", records=" +
+      records.size() +
+      " items}"
+    );
+  }
 }

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/SimpleQuery.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/SimpleQuery.java
@@ -1,0 +1,48 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.cryptography.dbencryptionsdk.dynamodb.testvectors.model;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A simple query definition with optional index, key expression, filter expression,
+ * and a list of config names for which this query is expected to fail.
+ */
+public class SimpleQuery {
+
+    private final String index;       // nullable
+    private final String keyExpr;     // nullable
+    private final String filterExpr;  // nullable
+    private final List<String> failConfigs;
+
+    public SimpleQuery(String index, String keyExpr, String filterExpr, List<String> failConfigs) {
+        this.index = index;
+        this.keyExpr = keyExpr;
+        this.filterExpr = filterExpr;
+        this.failConfigs = failConfigs != null ? Collections.unmodifiableList(failConfigs) : Collections.<String>emptyList();
+    }
+
+    public String getIndex() {
+        return index;
+    }
+
+    public String getKeyExpr() {
+        return keyExpr;
+    }
+
+    public String getFilterExpr() {
+        return filterExpr;
+    }
+
+    public List<String> getFailConfigs() {
+        return failConfigs;
+    }
+
+    @Override
+    public String toString() {
+        return "SimpleQuery{index='" + index + "', keyExpr='" + keyExpr
+                + "', filterExpr='" + filterExpr + "', failConfigs=" + failConfigs + "}";
+    }
+}

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/SimpleQuery.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/SimpleQuery.java
@@ -12,37 +12,54 @@ import java.util.List;
  */
 public class SimpleQuery {
 
-    private final String index;       // nullable
-    private final String keyExpr;     // nullable
-    private final String filterExpr;  // nullable
-    private final List<String> failConfigs;
+  private final String index; // nullable
+  private final String keyExpr; // nullable
+  private final String filterExpr; // nullable
+  private final List<String> failConfigs;
 
-    public SimpleQuery(String index, String keyExpr, String filterExpr, List<String> failConfigs) {
-        this.index = index;
-        this.keyExpr = keyExpr;
-        this.filterExpr = filterExpr;
-        this.failConfigs = failConfigs != null ? Collections.unmodifiableList(failConfigs) : Collections.<String>emptyList();
-    }
+  public SimpleQuery(
+    String index,
+    String keyExpr,
+    String filterExpr,
+    List<String> failConfigs
+  ) {
+    this.index = index;
+    this.keyExpr = keyExpr;
+    this.filterExpr = filterExpr;
+    this.failConfigs =
+      failConfigs != null
+        ? Collections.unmodifiableList(failConfigs)
+        : Collections.<String>emptyList();
+  }
 
-    public String getIndex() {
-        return index;
-    }
+  public String getIndex() {
+    return index;
+  }
 
-    public String getKeyExpr() {
-        return keyExpr;
-    }
+  public String getKeyExpr() {
+    return keyExpr;
+  }
 
-    public String getFilterExpr() {
-        return filterExpr;
-    }
+  public String getFilterExpr() {
+    return filterExpr;
+  }
 
-    public List<String> getFailConfigs() {
-        return failConfigs;
-    }
+  public List<String> getFailConfigs() {
+    return failConfigs;
+  }
 
-    @Override
-    public String toString() {
-        return "SimpleQuery{index='" + index + "', keyExpr='" + keyExpr
-                + "', filterExpr='" + filterExpr + "', failConfigs=" + failConfigs + "}";
-    }
+  @Override
+  public String toString() {
+    return (
+      "SimpleQuery{index='" +
+      index +
+      "', keyExpr='" +
+      keyExpr +
+      "', filterExpr='" +
+      filterExpr +
+      "', failConfigs=" +
+      failConfigs +
+      "}"
+    );
+  }
 }

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/TableConfig.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/TableConfig.java
@@ -1,0 +1,40 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.cryptography.dbencryptionsdk.dynamodb.testvectors.model;
+
+import software.amazon.cryptography.dbencryptionsdk.dynamodb.model.DynamoDbTableEncryptionConfig;
+
+/**
+ * A table encryption configuration with a name and a vanilla flag indicating
+ * whether encryption is disabled.
+ */
+public class TableConfig {
+
+    private final String name;
+    private final DynamoDbTableEncryptionConfig config;
+    private final boolean vanilla;
+
+    public TableConfig(String name, DynamoDbTableEncryptionConfig config, boolean vanilla) {
+        this.name = name;
+        this.config = config;
+        this.vanilla = vanilla;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public DynamoDbTableEncryptionConfig getConfig() {
+        return config;
+    }
+
+    public boolean isVanilla() {
+        return vanilla;
+    }
+
+    @Override
+    public String toString() {
+        return "TableConfig{name='" + name + "', vanilla=" + vanilla + "}";
+    }
+}

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/TableConfig.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/TableConfig.java
@@ -11,30 +11,34 @@ import software.amazon.cryptography.dbencryptionsdk.dynamodb.model.DynamoDbTable
  */
 public class TableConfig {
 
-    private final String name;
-    private final DynamoDbTableEncryptionConfig config;
-    private final boolean vanilla;
+  private final String name;
+  private final DynamoDbTableEncryptionConfig config;
+  private final boolean vanilla;
 
-    public TableConfig(String name, DynamoDbTableEncryptionConfig config, boolean vanilla) {
-        this.name = name;
-        this.config = config;
-        this.vanilla = vanilla;
-    }
+  public TableConfig(
+    String name,
+    DynamoDbTableEncryptionConfig config,
+    boolean vanilla
+  ) {
+    this.name = name;
+    this.config = config;
+    this.vanilla = vanilla;
+  }
 
-    public String getName() {
-        return name;
-    }
+  public String getName() {
+    return name;
+  }
 
-    public DynamoDbTableEncryptionConfig getConfig() {
-        return config;
-    }
+  public DynamoDbTableEncryptionConfig getConfig() {
+    return config;
+  }
 
-    public boolean isVanilla() {
-        return vanilla;
-    }
+  public boolean isVanilla() {
+    return vanilla;
+  }
 
-    @Override
-    public String toString() {
-        return "TableConfig{name='" + name + "', vanilla=" + vanilla + "}";
-    }
+  @Override
+  public String toString() {
+    return "TableConfig{name='" + name + "', vanilla=" + vanilla + "}";
+  }
 }

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/TestVectorConfig.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/TestVectorConfig.java
@@ -35,22 +35,22 @@ public class TestVectorConfig {
   private CreateTableRequest schemaOnEncrypt;
 
   public TestVectorConfig() {
-    this.globalRecords = new ArrayList<Record>();
-    this.tableEncryptionConfigs = new HashMap<String, TableConfig>();
-    this.largeEncryptionConfigs = new HashMap<String, TableConfig>();
-    this.queries = new ArrayList<SimpleQuery>();
-    this.names = new HashMap<String, String>();
-    this.values = new HashMap<String, AttributeValue>();
-    this.failingQueries = new ArrayList<SimpleQuery>();
-    this.complexTests = new ArrayList<ComplexTest>();
-    this.ioTests = new ArrayList<IoTest>();
-    this.configsForIoTest = new ArrayList<ConfigPair>();
-    this.configsForModTest = new ArrayList<ConfigPair>();
-    this.writeTests = new ArrayList<WriteTest>();
-    this.roundTripTests = new ArrayList<RoundTripTest>();
-    this.decryptTests = new ArrayList<DecryptTest>();
-    this.strings = new ArrayList<String>();
-    this.large = new ArrayList<LargeRecord>();
+    this.globalRecords = new ArrayList<>();
+    this.tableEncryptionConfigs = new HashMap<>();
+    this.largeEncryptionConfigs = new HashMap<>();
+    this.queries = new ArrayList<>();
+    this.names = new HashMap<>();
+    this.values = new HashMap<>();
+    this.failingQueries = new ArrayList<>();
+    this.complexTests = new ArrayList<>();
+    this.ioTests = new ArrayList<>();
+    this.configsForIoTest = new ArrayList<>();
+    this.configsForModTest = new ArrayList<>();
+    this.writeTests = new ArrayList<>();
+    this.roundTripTests = new ArrayList<>();
+    this.decryptTests = new ArrayList<>();
+    this.strings = new ArrayList<>();
+    this.large = new ArrayList<>();
   }
 
   public List<Record> getGlobalRecords() {

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/TestVectorConfig.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/TestVectorConfig.java
@@ -4,7 +4,6 @@
 package software.amazon.cryptography.dbencryptionsdk.dynamodb.testvectors.model;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/TestVectorConfig.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/TestVectorConfig.java
@@ -1,0 +1,207 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.cryptography.dbencryptionsdk.dynamodb.testvectors.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+
+/**
+ * Aggregate data structure holding all parsed test vector data including records,
+ * configs, queries, tests, and string ordering data.
+ */
+public class TestVectorConfig {
+
+    private List<Record> globalRecords;
+    private Map<String, TableConfig> tableEncryptionConfigs;
+    private Map<String, TableConfig> largeEncryptionConfigs;
+    private List<SimpleQuery> queries;
+    private Map<String, String> names;
+    private Map<String, AttributeValue> values;
+    private List<SimpleQuery> failingQueries;
+    private List<ComplexTest> complexTests;
+    private List<IoTest> ioTests;
+    private List<String[]> configsForIoTest;
+    private List<String[]> configsForModTest;
+    private List<WriteTest> writeTests;
+    private List<RoundTripTest> roundTripTests;
+    private List<DecryptTest> decryptTests;
+    private List<String> strings;
+    private List<LargeRecord> large;
+    private CreateTableRequest schemaOnEncrypt;
+
+    public TestVectorConfig() {
+        this.globalRecords = new ArrayList<Record>();
+        this.tableEncryptionConfigs = new HashMap<String, TableConfig>();
+        this.largeEncryptionConfigs = new HashMap<String, TableConfig>();
+        this.queries = new ArrayList<SimpleQuery>();
+        this.names = new HashMap<String, String>();
+        this.values = new HashMap<String, AttributeValue>();
+        this.failingQueries = new ArrayList<SimpleQuery>();
+        this.complexTests = new ArrayList<ComplexTest>();
+        this.ioTests = new ArrayList<IoTest>();
+        this.configsForIoTest = new ArrayList<String[]>();
+        this.configsForModTest = new ArrayList<String[]>();
+        this.writeTests = new ArrayList<WriteTest>();
+        this.roundTripTests = new ArrayList<RoundTripTest>();
+        this.decryptTests = new ArrayList<DecryptTest>();
+        this.strings = new ArrayList<String>();
+        this.large = new ArrayList<LargeRecord>();
+    }
+
+    public List<Record> getGlobalRecords() {
+        return globalRecords;
+    }
+
+    public void setGlobalRecords(List<Record> globalRecords) {
+        this.globalRecords = globalRecords;
+    }
+
+    public Map<String, TableConfig> getTableEncryptionConfigs() {
+        return tableEncryptionConfigs;
+    }
+
+    public void setTableEncryptionConfigs(Map<String, TableConfig> tableEncryptionConfigs) {
+        this.tableEncryptionConfigs = tableEncryptionConfigs;
+    }
+
+    public Map<String, TableConfig> getLargeEncryptionConfigs() {
+        return largeEncryptionConfigs;
+    }
+
+    public void setLargeEncryptionConfigs(Map<String, TableConfig> largeEncryptionConfigs) {
+        this.largeEncryptionConfigs = largeEncryptionConfigs;
+    }
+
+    public List<SimpleQuery> getQueries() {
+        return queries;
+    }
+
+    public void setQueries(List<SimpleQuery> queries) {
+        this.queries = queries;
+    }
+
+    public Map<String, String> getNames() {
+        return names;
+    }
+
+    public void setNames(Map<String, String> names) {
+        this.names = names;
+    }
+
+    public Map<String, AttributeValue> getValues() {
+        return values;
+    }
+
+    public void setValues(Map<String, AttributeValue> values) {
+        this.values = values;
+    }
+
+    public List<SimpleQuery> getFailingQueries() {
+        return failingQueries;
+    }
+
+    public void setFailingQueries(List<SimpleQuery> failingQueries) {
+        this.failingQueries = failingQueries;
+    }
+
+    public List<ComplexTest> getComplexTests() {
+        return complexTests;
+    }
+
+    public void setComplexTests(List<ComplexTest> complexTests) {
+        this.complexTests = complexTests;
+    }
+
+    public List<IoTest> getIoTests() {
+        return ioTests;
+    }
+
+    public void setIoTests(List<IoTest> ioTests) {
+        this.ioTests = ioTests;
+    }
+
+    public List<String[]> getConfigsForIoTest() {
+        return configsForIoTest;
+    }
+
+    public void setConfigsForIoTest(List<String[]> configsForIoTest) {
+        this.configsForIoTest = configsForIoTest;
+    }
+
+    public List<String[]> getConfigsForModTest() {
+        return configsForModTest;
+    }
+
+    public void setConfigsForModTest(List<String[]> configsForModTest) {
+        this.configsForModTest = configsForModTest;
+    }
+
+    public List<WriteTest> getWriteTests() {
+        return writeTests;
+    }
+
+    public void setWriteTests(List<WriteTest> writeTests) {
+        this.writeTests = writeTests;
+    }
+
+    public List<RoundTripTest> getRoundTripTests() {
+        return roundTripTests;
+    }
+
+    public void setRoundTripTests(List<RoundTripTest> roundTripTests) {
+        this.roundTripTests = roundTripTests;
+    }
+
+    public List<DecryptTest> getDecryptTests() {
+        return decryptTests;
+    }
+
+    public void setDecryptTests(List<DecryptTest> decryptTests) {
+        this.decryptTests = decryptTests;
+    }
+
+    public List<String> getStrings() {
+        return strings;
+    }
+
+    public void setStrings(List<String> strings) {
+        this.strings = strings;
+    }
+
+    public List<LargeRecord> getLarge() {
+        return large;
+    }
+
+    public void setLarge(List<LargeRecord> large) {
+        this.large = large;
+    }
+
+    public CreateTableRequest getSchemaOnEncrypt() {
+        return schemaOnEncrypt;
+    }
+
+    public void setSchemaOnEncrypt(CreateTableRequest schemaOnEncrypt) {
+        this.schemaOnEncrypt = schemaOnEncrypt;
+    }
+
+    @Override
+    public String toString() {
+        return "TestVectorConfig{"
+                + "globalRecords=" + globalRecords.size()
+                + ", tableEncryptionConfigs=" + tableEncryptionConfigs.size()
+                + ", largeEncryptionConfigs=" + largeEncryptionConfigs.size()
+                + ", queries=" + queries.size()
+                + ", ioTests=" + ioTests.size()
+                + ", complexTests=" + complexTests.size()
+                + ", writeTests=" + writeTests.size()
+                + ", roundTripTests=" + roundTripTests.size()
+                + ", decryptTests=" + decryptTests.size()
+                + "}";
+    }
+}

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/TestVectorConfig.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/TestVectorConfig.java
@@ -17,191 +17,206 @@ import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
  */
 public class TestVectorConfig {
 
-    private List<Record> globalRecords;
-    private Map<String, TableConfig> tableEncryptionConfigs;
-    private Map<String, TableConfig> largeEncryptionConfigs;
-    private List<SimpleQuery> queries;
-    private Map<String, String> names;
-    private Map<String, AttributeValue> values;
-    private List<SimpleQuery> failingQueries;
-    private List<ComplexTest> complexTests;
-    private List<IoTest> ioTests;
-    private List<String[]> configsForIoTest;
-    private List<String[]> configsForModTest;
-    private List<WriteTest> writeTests;
-    private List<RoundTripTest> roundTripTests;
-    private List<DecryptTest> decryptTests;
-    private List<String> strings;
-    private List<LargeRecord> large;
-    private CreateTableRequest schemaOnEncrypt;
+  private List<Record> globalRecords;
+  private Map<String, TableConfig> tableEncryptionConfigs;
+  private Map<String, TableConfig> largeEncryptionConfigs;
+  private List<SimpleQuery> queries;
+  private Map<String, String> names;
+  private Map<String, AttributeValue> values;
+  private List<SimpleQuery> failingQueries;
+  private List<ComplexTest> complexTests;
+  private List<IoTest> ioTests;
+  private List<String[]> configsForIoTest;
+  private List<String[]> configsForModTest;
+  private List<WriteTest> writeTests;
+  private List<RoundTripTest> roundTripTests;
+  private List<DecryptTest> decryptTests;
+  private List<String> strings;
+  private List<LargeRecord> large;
+  private CreateTableRequest schemaOnEncrypt;
 
-    public TestVectorConfig() {
-        this.globalRecords = new ArrayList<Record>();
-        this.tableEncryptionConfigs = new HashMap<String, TableConfig>();
-        this.largeEncryptionConfigs = new HashMap<String, TableConfig>();
-        this.queries = new ArrayList<SimpleQuery>();
-        this.names = new HashMap<String, String>();
-        this.values = new HashMap<String, AttributeValue>();
-        this.failingQueries = new ArrayList<SimpleQuery>();
-        this.complexTests = new ArrayList<ComplexTest>();
-        this.ioTests = new ArrayList<IoTest>();
-        this.configsForIoTest = new ArrayList<String[]>();
-        this.configsForModTest = new ArrayList<String[]>();
-        this.writeTests = new ArrayList<WriteTest>();
-        this.roundTripTests = new ArrayList<RoundTripTest>();
-        this.decryptTests = new ArrayList<DecryptTest>();
-        this.strings = new ArrayList<String>();
-        this.large = new ArrayList<LargeRecord>();
-    }
+  public TestVectorConfig() {
+    this.globalRecords = new ArrayList<Record>();
+    this.tableEncryptionConfigs = new HashMap<String, TableConfig>();
+    this.largeEncryptionConfigs = new HashMap<String, TableConfig>();
+    this.queries = new ArrayList<SimpleQuery>();
+    this.names = new HashMap<String, String>();
+    this.values = new HashMap<String, AttributeValue>();
+    this.failingQueries = new ArrayList<SimpleQuery>();
+    this.complexTests = new ArrayList<ComplexTest>();
+    this.ioTests = new ArrayList<IoTest>();
+    this.configsForIoTest = new ArrayList<String[]>();
+    this.configsForModTest = new ArrayList<String[]>();
+    this.writeTests = new ArrayList<WriteTest>();
+    this.roundTripTests = new ArrayList<RoundTripTest>();
+    this.decryptTests = new ArrayList<DecryptTest>();
+    this.strings = new ArrayList<String>();
+    this.large = new ArrayList<LargeRecord>();
+  }
 
-    public List<Record> getGlobalRecords() {
-        return globalRecords;
-    }
+  public List<Record> getGlobalRecords() {
+    return globalRecords;
+  }
 
-    public void setGlobalRecords(List<Record> globalRecords) {
-        this.globalRecords = globalRecords;
-    }
+  public void setGlobalRecords(List<Record> globalRecords) {
+    this.globalRecords = globalRecords;
+  }
 
-    public Map<String, TableConfig> getTableEncryptionConfigs() {
-        return tableEncryptionConfigs;
-    }
+  public Map<String, TableConfig> getTableEncryptionConfigs() {
+    return tableEncryptionConfigs;
+  }
 
-    public void setTableEncryptionConfigs(Map<String, TableConfig> tableEncryptionConfigs) {
-        this.tableEncryptionConfigs = tableEncryptionConfigs;
-    }
+  public void setTableEncryptionConfigs(
+    Map<String, TableConfig> tableEncryptionConfigs
+  ) {
+    this.tableEncryptionConfigs = tableEncryptionConfigs;
+  }
 
-    public Map<String, TableConfig> getLargeEncryptionConfigs() {
-        return largeEncryptionConfigs;
-    }
+  public Map<String, TableConfig> getLargeEncryptionConfigs() {
+    return largeEncryptionConfigs;
+  }
 
-    public void setLargeEncryptionConfigs(Map<String, TableConfig> largeEncryptionConfigs) {
-        this.largeEncryptionConfigs = largeEncryptionConfigs;
-    }
+  public void setLargeEncryptionConfigs(
+    Map<String, TableConfig> largeEncryptionConfigs
+  ) {
+    this.largeEncryptionConfigs = largeEncryptionConfigs;
+  }
 
-    public List<SimpleQuery> getQueries() {
-        return queries;
-    }
+  public List<SimpleQuery> getQueries() {
+    return queries;
+  }
 
-    public void setQueries(List<SimpleQuery> queries) {
-        this.queries = queries;
-    }
+  public void setQueries(List<SimpleQuery> queries) {
+    this.queries = queries;
+  }
 
-    public Map<String, String> getNames() {
-        return names;
-    }
+  public Map<String, String> getNames() {
+    return names;
+  }
 
-    public void setNames(Map<String, String> names) {
-        this.names = names;
-    }
+  public void setNames(Map<String, String> names) {
+    this.names = names;
+  }
 
-    public Map<String, AttributeValue> getValues() {
-        return values;
-    }
+  public Map<String, AttributeValue> getValues() {
+    return values;
+  }
 
-    public void setValues(Map<String, AttributeValue> values) {
-        this.values = values;
-    }
+  public void setValues(Map<String, AttributeValue> values) {
+    this.values = values;
+  }
 
-    public List<SimpleQuery> getFailingQueries() {
-        return failingQueries;
-    }
+  public List<SimpleQuery> getFailingQueries() {
+    return failingQueries;
+  }
 
-    public void setFailingQueries(List<SimpleQuery> failingQueries) {
-        this.failingQueries = failingQueries;
-    }
+  public void setFailingQueries(List<SimpleQuery> failingQueries) {
+    this.failingQueries = failingQueries;
+  }
 
-    public List<ComplexTest> getComplexTests() {
-        return complexTests;
-    }
+  public List<ComplexTest> getComplexTests() {
+    return complexTests;
+  }
 
-    public void setComplexTests(List<ComplexTest> complexTests) {
-        this.complexTests = complexTests;
-    }
+  public void setComplexTests(List<ComplexTest> complexTests) {
+    this.complexTests = complexTests;
+  }
 
-    public List<IoTest> getIoTests() {
-        return ioTests;
-    }
+  public List<IoTest> getIoTests() {
+    return ioTests;
+  }
 
-    public void setIoTests(List<IoTest> ioTests) {
-        this.ioTests = ioTests;
-    }
+  public void setIoTests(List<IoTest> ioTests) {
+    this.ioTests = ioTests;
+  }
 
-    public List<String[]> getConfigsForIoTest() {
-        return configsForIoTest;
-    }
+  public List<String[]> getConfigsForIoTest() {
+    return configsForIoTest;
+  }
 
-    public void setConfigsForIoTest(List<String[]> configsForIoTest) {
-        this.configsForIoTest = configsForIoTest;
-    }
+  public void setConfigsForIoTest(List<String[]> configsForIoTest) {
+    this.configsForIoTest = configsForIoTest;
+  }
 
-    public List<String[]> getConfigsForModTest() {
-        return configsForModTest;
-    }
+  public List<String[]> getConfigsForModTest() {
+    return configsForModTest;
+  }
 
-    public void setConfigsForModTest(List<String[]> configsForModTest) {
-        this.configsForModTest = configsForModTest;
-    }
+  public void setConfigsForModTest(List<String[]> configsForModTest) {
+    this.configsForModTest = configsForModTest;
+  }
 
-    public List<WriteTest> getWriteTests() {
-        return writeTests;
-    }
+  public List<WriteTest> getWriteTests() {
+    return writeTests;
+  }
 
-    public void setWriteTests(List<WriteTest> writeTests) {
-        this.writeTests = writeTests;
-    }
+  public void setWriteTests(List<WriteTest> writeTests) {
+    this.writeTests = writeTests;
+  }
 
-    public List<RoundTripTest> getRoundTripTests() {
-        return roundTripTests;
-    }
+  public List<RoundTripTest> getRoundTripTests() {
+    return roundTripTests;
+  }
 
-    public void setRoundTripTests(List<RoundTripTest> roundTripTests) {
-        this.roundTripTests = roundTripTests;
-    }
+  public void setRoundTripTests(List<RoundTripTest> roundTripTests) {
+    this.roundTripTests = roundTripTests;
+  }
 
-    public List<DecryptTest> getDecryptTests() {
-        return decryptTests;
-    }
+  public List<DecryptTest> getDecryptTests() {
+    return decryptTests;
+  }
 
-    public void setDecryptTests(List<DecryptTest> decryptTests) {
-        this.decryptTests = decryptTests;
-    }
+  public void setDecryptTests(List<DecryptTest> decryptTests) {
+    this.decryptTests = decryptTests;
+  }
 
-    public List<String> getStrings() {
-        return strings;
-    }
+  public List<String> getStrings() {
+    return strings;
+  }
 
-    public void setStrings(List<String> strings) {
-        this.strings = strings;
-    }
+  public void setStrings(List<String> strings) {
+    this.strings = strings;
+  }
 
-    public List<LargeRecord> getLarge() {
-        return large;
-    }
+  public List<LargeRecord> getLarge() {
+    return large;
+  }
 
-    public void setLarge(List<LargeRecord> large) {
-        this.large = large;
-    }
+  public void setLarge(List<LargeRecord> large) {
+    this.large = large;
+  }
 
-    public CreateTableRequest getSchemaOnEncrypt() {
-        return schemaOnEncrypt;
-    }
+  public CreateTableRequest getSchemaOnEncrypt() {
+    return schemaOnEncrypt;
+  }
 
-    public void setSchemaOnEncrypt(CreateTableRequest schemaOnEncrypt) {
-        this.schemaOnEncrypt = schemaOnEncrypt;
-    }
+  public void setSchemaOnEncrypt(CreateTableRequest schemaOnEncrypt) {
+    this.schemaOnEncrypt = schemaOnEncrypt;
+  }
 
-    @Override
-    public String toString() {
-        return "TestVectorConfig{"
-                + "globalRecords=" + globalRecords.size()
-                + ", tableEncryptionConfigs=" + tableEncryptionConfigs.size()
-                + ", largeEncryptionConfigs=" + largeEncryptionConfigs.size()
-                + ", queries=" + queries.size()
-                + ", ioTests=" + ioTests.size()
-                + ", complexTests=" + complexTests.size()
-                + ", writeTests=" + writeTests.size()
-                + ", roundTripTests=" + roundTripTests.size()
-                + ", decryptTests=" + decryptTests.size()
-                + "}";
-    }
+  @Override
+  public String toString() {
+    return (
+      "TestVectorConfig{" +
+      "globalRecords=" +
+      globalRecords.size() +
+      ", tableEncryptionConfigs=" +
+      tableEncryptionConfigs.size() +
+      ", largeEncryptionConfigs=" +
+      largeEncryptionConfigs.size() +
+      ", queries=" +
+      queries.size() +
+      ", ioTests=" +
+      ioTests.size() +
+      ", complexTests=" +
+      complexTests.size() +
+      ", writeTests=" +
+      writeTests.size() +
+      ", roundTripTests=" +
+      roundTripTests.size() +
+      ", decryptTests=" +
+      decryptTests.size() +
+      "}"
+    );
+  }
 }

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/TestVectorConfig.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/TestVectorConfig.java
@@ -25,8 +25,8 @@ public class TestVectorConfig {
   private List<SimpleQuery> failingQueries;
   private List<ComplexTest> complexTests;
   private List<IoTest> ioTests;
-  private List<String[]> configsForIoTest;
-  private List<String[]> configsForModTest;
+  private List<ConfigPair> configsForIoTest;
+  private List<ConfigPair> configsForModTest;
   private List<WriteTest> writeTests;
   private List<RoundTripTest> roundTripTests;
   private List<DecryptTest> decryptTests;
@@ -44,8 +44,8 @@ public class TestVectorConfig {
     this.failingQueries = new ArrayList<SimpleQuery>();
     this.complexTests = new ArrayList<ComplexTest>();
     this.ioTests = new ArrayList<IoTest>();
-    this.configsForIoTest = new ArrayList<String[]>();
-    this.configsForModTest = new ArrayList<String[]>();
+    this.configsForIoTest = new ArrayList<ConfigPair>();
+    this.configsForModTest = new ArrayList<ConfigPair>();
     this.writeTests = new ArrayList<WriteTest>();
     this.roundTripTests = new ArrayList<RoundTripTest>();
     this.decryptTests = new ArrayList<DecryptTest>();
@@ -129,19 +129,19 @@ public class TestVectorConfig {
     this.ioTests = ioTests;
   }
 
-  public List<String[]> getConfigsForIoTest() {
+  public List<ConfigPair> getConfigsForIoTest() {
     return configsForIoTest;
   }
 
-  public void setConfigsForIoTest(List<String[]> configsForIoTest) {
+  public void setConfigsForIoTest(List<ConfigPair> configsForIoTest) {
     this.configsForIoTest = configsForIoTest;
   }
 
-  public List<String[]> getConfigsForModTest() {
+  public List<ConfigPair> getConfigsForModTest() {
     return configsForModTest;
   }
 
-  public void setConfigsForModTest(List<String[]> configsForModTest) {
+  public void setConfigsForModTest(List<ConfigPair> configsForModTest) {
     this.configsForModTest = configsForModTest;
   }
 

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/WriteTest.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/WriteTest.java
@@ -11,31 +11,41 @@ import java.util.List;
  */
 public class WriteTest {
 
-    private final TableConfig config;
-    private final List<Record> records;
-    private final String fileName;
+  private final TableConfig config;
+  private final List<Record> records;
+  private final String fileName;
 
-    public WriteTest(TableConfig config, List<Record> records, String fileName) {
-        this.config = config;
-        this.records = records != null ? Collections.unmodifiableList(records) : Collections.<Record>emptyList();
-        this.fileName = fileName;
-    }
+  public WriteTest(TableConfig config, List<Record> records, String fileName) {
+    this.config = config;
+    this.records =
+      records != null
+        ? Collections.unmodifiableList(records)
+        : Collections.<Record>emptyList();
+    this.fileName = fileName;
+  }
 
-    public TableConfig getConfig() {
-        return config;
-    }
+  public TableConfig getConfig() {
+    return config;
+  }
 
-    public List<Record> getRecords() {
-        return records;
-    }
+  public List<Record> getRecords() {
+    return records;
+  }
 
-    public String getFileName() {
-        return fileName;
-    }
+  public String getFileName() {
+    return fileName;
+  }
 
-    @Override
-    public String toString() {
-        return "WriteTest{config=" + config + ", records=" + records.size()
-                + " items, fileName='" + fileName + "'}";
-    }
+  @Override
+  public String toString() {
+    return (
+      "WriteTest{config=" +
+      config +
+      ", records=" +
+      records.size() +
+      " items, fileName='" +
+      fileName +
+      "'}"
+    );
+  }
 }

--- a/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/WriteTest.java
+++ b/TestVectors/runtimes/java/src/main/java/software/amazon/cryptography/dbencryptionsdk/dynamodb/testvectors/model/WriteTest.java
@@ -1,0 +1,41 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.cryptography.dbencryptionsdk.dynamodb.testvectors.model;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A write test definition containing a config, records to encrypt, and an output file name.
+ */
+public class WriteTest {
+
+    private final TableConfig config;
+    private final List<Record> records;
+    private final String fileName;
+
+    public WriteTest(TableConfig config, List<Record> records, String fileName) {
+        this.config = config;
+        this.records = records != null ? Collections.unmodifiableList(records) : Collections.<Record>emptyList();
+        this.fileName = fileName;
+    }
+
+    public TableConfig getConfig() {
+        return config;
+    }
+
+    public List<Record> getRecords() {
+        return records;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    @Override
+    public String toString() {
+        return "WriteTest{config=" + config + ", records=" + records.size()
+                + " items, fileName='" + fileName + "'}";
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

First PR in the TestVectors native Java rewrite series. Sets up the build configuration and introduces the core data model classes that replace the Dafny-generated types.

## What changed

### Dafny → Java mapping

| Dafny Source (`TestVectors/dafny/DDBEncryption/src/JsonConfig.dfy`) | Native Java Class |
|---|---|
| `datatype Record` ([line 47](https://github.com/aws/aws-database-encryption-sdk-dynamodb/blob/main/TestVectors/dafny/DDBEncryption/src/JsonConfig.dfy#L47-L50)) | `model/Record.java` |
| `datatype LargeRecord` [line 52](https://github.com/aws/aws-database-encryption-sdk-dynamodb/blob/main/TestVectors/dafny/DDBEncryption/src/JsonConfig.dfy#L52-L55) | `model/LargeRecord.java` |
| `datatype TableConfig` [line 57](https://github.com/aws/aws-database-encryption-sdk-dynamodb/blob/main/TestVectors/dafny/DDBEncryption/src/JsonConfig.dfy#L57-L61) | `model/TableConfig.java` |
| `datatype SimpleQuery` [line 63](https://github.com/aws/aws-database-encryption-sdk-dynamodb/blob/main/TestVectors/dafny/DDBEncryption/src/JsonConfig.dfy#L63-L68) | `model/SimpleQuery.java` |
| `datatype ComplexQuery` [line 70](https://github.com/aws/aws-database-encryption-sdk-dynamodb/blob/main/TestVectors/dafny/DDBEncryption/src/JsonConfig.dfy#L70-L74) | `model/ComplexQuery.java` |
| `datatype ComplexTest` [line 76](https://github.com/aws/aws-database-encryption-sdk-dynamodb/blob/main/TestVectors/dafny/DDBEncryption/src/JsonConfig.dfy#L76-L80) | `model/ComplexTest.java` |
| `datatype IoTest` [line 98](https://github.com/aws/aws-database-encryption-sdk-dynamodb/blob/main/TestVectors/dafny/DDBEncryption/src/JsonConfig.dfy#L98-L106) | `model/IoTest.java` |
| `datatype RoundTripTest` [line 82](https://github.com/aws/aws-database-encryption-sdk-dynamodb/blob/main/TestVectors/dafny/DDBEncryption/src/JsonConfig.dfy#L82-L85) | `model/RoundTripTest.java` |
| `datatype WriteTest` [line 87](https://github.com/aws/aws-database-encryption-sdk-dynamodb/blob/main/TestVectors/dafny/DDBEncryption/src/JsonConfig.dfy#L87-L91) | `model/WriteTest.java` |
| `datatype DecryptTest` [line 92](https://github.com/aws/aws-database-encryption-sdk-dynamodb/blob/main/TestVectors/dafny/DDBEncryption/src/JsonConfig.dfy#L92-L96) | `model/DecryptTest.java` |
| `datatype TestVectorConfig` (in `TestVectors.dfy` [line 53](https://github.com/aws/aws-database-encryption-sdk-dynamodb/blob/main/TestVectors/dafny/DDBEncryption/src/TestVectors.dfy#L53-L71)) | `model/TestVectorConfig.java` |
| `type ConfigPair = (ConfigName, ConfigName)` ([line 111](https://github.com/aws/aws-database-encryption-sdk-dynamodb/blob/main/TestVectors/dafny/DDBEncryption/src/JsonConfig.dfy#L111)) | `model/ConfigPair.java` |

### Key type translations

| Dafny Type | Java Type |
|---|---|
| `DDB.AttributeMap` | `Map<String, AttributeValue>` |
| `Option<T>` | Nullable field (Java 8 compat) |
| `seq<T>` | `List<T>` |
| `map<K, V>` | `Map<K, V>` |
| `ConfigPair = (string, string)` | `String[]` (length 2) |
| `DDB.CreateTableInput` | `CreateTableRequest` |
| `Types.DynamoDbTableEncryptionConfig` | `DynamoDbTableEncryptionConfig` (native DBESDK) |

## Testing

- `gradle clean compileJava` passes with no errors

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
