### PR TITLE
chore: pin time crate to fix CI 

### DIFF
--- a/DynamoDbEncryption/runtimes/rust/Cargo.toml
+++ b/DynamoDbEncryption/runtimes/rust/Cargo.toml
@@ -22,7 +22,9 @@ aws-lc-fips-sys = { version = "0.13", optional = true }
 aws-sdk-dynamodb = "1.103.0"
 aws-sdk-kms = "1.98.0"
 aws-smithy-runtime-api = {version = "1.10.0", features = ["client"] }
-aws-smithy-types = "1.3.6"
+# aws-smithy-types 1.5.0 pulls time 0.3.48 which has a coherence conflict (E0119)
+# with CanDisable<T>'s blanket From impl on rustc >= 1.80. Pin until upstream fixes it.
+aws-smithy-types = ">=1.3.6, <1.5.0"
 chrono = "0.4.43"
 cpu-time = "1.0.0"
 dafny_runtime = { path = "../../../submodules/smithy-dafny/TestModels/dafny-dependencies/dafny_runtime_rust", features = ["sync","small-int"] }

--- a/DynamoDbEncryption/runtimes/rust/Cargo.toml
+++ b/DynamoDbEncryption/runtimes/rust/Cargo.toml
@@ -22,9 +22,12 @@ aws-lc-fips-sys = { version = "0.13", optional = true }
 aws-sdk-dynamodb = "1.103.0"
 aws-sdk-kms = "1.98.0"
 aws-smithy-runtime-api = {version = "1.10.0", features = ["client"] }
-# aws-smithy-types 1.5.0 pulls time 0.3.48 which has a coherence conflict (E0119)
-# with CanDisable<T>'s blanket From impl on rustc >= 1.80. Pin until upstream fixes it.
-aws-smithy-types = ">=1.3.6, <1.5.0"
+# aws-smithy-types has a coherence conflict (E0119) with time >= 0.3.37 on rustc >= 1.80.
+# time 0.3.37+ introduces ModifierValue associated type impls that conflict with
+# CanDisable<T>'s blanket `impl<T> From<T>`. Pin time until upstream fixes it.
+# See: https://github.com/time-rs/time/issues/720
+time = ">=0.3.0, <0.3.37"
+aws-smithy-types = "1.3.6"
 chrono = "0.4.43"
 cpu-time = "1.0.0"
 dafny_runtime = { path = "../../../submodules/smithy-dafny/TestModels/dafny-dependencies/dafny_runtime_rust", features = ["sync","small-int"] }

--- a/TestVectors/runtimes/rust/Cargo.toml
+++ b/TestVectors/runtimes/rust/Cargo.toml
@@ -13,7 +13,9 @@ aws-lc-fips-sys = { version = "0.13", optional = true }
 aws-sdk-dynamodb = "1.103.0"
 aws-sdk-kms = "1.98.0"
 aws-smithy-runtime-api = {version = "1.10.0", features = ["client"] }
-aws-smithy-types = "1.3.6"
+# aws-smithy-types 1.5.0 pulls time 0.3.48 which has a coherence conflict (E0119)
+# with CanDisable<T>'s blanket From impl on rustc >= 1.80. Pin until upstream fixes it.
+aws-smithy-types = ">=1.3.6, <1.5.0"
 chrono = "0.4.43"
 cpu-time = "1.0.0"
 dafny_runtime = { path = "../../../submodules/smithy-dafny/TestModels/dafny-dependencies/dafny_runtime_rust", features = ["sync","small-int"] }

--- a/TestVectors/runtimes/rust/Cargo.toml
+++ b/TestVectors/runtimes/rust/Cargo.toml
@@ -13,9 +13,11 @@ aws-lc-fips-sys = { version = "0.13", optional = true }
 aws-sdk-dynamodb = "1.103.0"
 aws-sdk-kms = "1.98.0"
 aws-smithy-runtime-api = {version = "1.10.0", features = ["client"] }
-# aws-smithy-types 1.5.0 pulls time 0.3.48 which has a coherence conflict (E0119)
-# with CanDisable<T>'s blanket From impl on rustc >= 1.80. Pin until upstream fixes it.
-aws-smithy-types = ">=1.3.6, <1.5.0"
+# aws-smithy-types has a coherence conflict (E0119) with time >= 0.3.37 on rustc >= 1.80.
+# time 0.3.37+ introduces ModifierValue associated type impls that conflict with
+# CanDisable<T>'s blanket `impl<T> From<T>`. Pin time until upstream fixes it.
+time = ">=0.3.0, <0.3.37"
+aws-smithy-types = "1.3.6"
 chrono = "0.4.43"
 cpu-time = "1.0.0"
 dafny_runtime = { path = "../../../submodules/smithy-dafny/TestModels/dafny-dependencies/dafny_runtime_rust", features = ["sync","small-int"] }

--- a/db-esdk-performance-testing/benchmarks/rust/Cargo.toml
+++ b/db-esdk-performance-testing/benchmarks/rust/Cargo.toml
@@ -58,7 +58,7 @@ aws-sdk-sts = "1.96.0"
 # time 0.3.37+ introduces ModifierValue associated type impls that conflict with
 # CanDisable<T>'s blanket `impl<T> From<T>`. Pin time until upstream fixes it.
 time = ">=0.3.0, <0.3.37"
-aws-smithy-types = ">=1.3, <1.5.0"
+aws-smithy-types = "1.3"
 cpu-time = "1.0.0"
 
 [dev-dependencies]

--- a/db-esdk-performance-testing/benchmarks/rust/Cargo.toml
+++ b/db-esdk-performance-testing/benchmarks/rust/Cargo.toml
@@ -54,7 +54,9 @@ aws-sdk-kms = "1.98.0"
 aws-sdk-sso = "1.92.0"
 aws-sdk-ssooidc = "1.94.0"
 aws-sdk-sts = "1.96.0"
-aws-smithy-types = "1.3"
+# aws-smithy-types 1.5.0 pulls time 0.3.48 which has a coherence conflict (E0119)
+# with CanDisable<T>'s blanket From impl on rustc >= 1.80. Pin until upstream fixes it.
+aws-smithy-types = ">=1.3, <1.5.0"
 cpu-time = "1.0.0"
 
 [dev-dependencies]

--- a/db-esdk-performance-testing/benchmarks/rust/Cargo.toml
+++ b/db-esdk-performance-testing/benchmarks/rust/Cargo.toml
@@ -54,8 +54,10 @@ aws-sdk-kms = "1.98.0"
 aws-sdk-sso = "1.92.0"
 aws-sdk-ssooidc = "1.94.0"
 aws-sdk-sts = "1.96.0"
-# aws-smithy-types 1.5.0 pulls time 0.3.48 which has a coherence conflict (E0119)
-# with CanDisable<T>'s blanket From impl on rustc >= 1.80. Pin until upstream fixes it.
+# aws-smithy-types has a coherence conflict (E0119) with time >= 0.3.37 on rustc >= 1.80.
+# time 0.3.37+ introduces ModifierValue associated type impls that conflict with
+# CanDisable<T>'s blanket `impl<T> From<T>`. Pin time until upstream fixes it.
+time = ">=0.3.0, <0.3.37"
 aws-smithy-types = ">=1.3, <1.5.0"
 cpu-time = "1.0.0"
 

--- a/releases/rust/db_esdk/Cargo.toml
+++ b/releases/rust/db_esdk/Cargo.toml
@@ -22,7 +22,9 @@ aws-lc-fips-sys = { version = "0.13", optional = true }
 aws-sdk-dynamodb = "1.103.0"
 aws-sdk-kms = "1.98.0"
 aws-smithy-runtime-api = {version = "1.10.0", features = ["client"] }
-aws-smithy-types = "1.3.6"
+# aws-smithy-types 1.5.0 pulls time 0.3.48 which has a coherence conflict (E0119)
+# with CanDisable<T>'s blanket From impl on rustc >= 1.80. Pin until upstream fixes it.
+aws-smithy-types = ">=1.3.6, <1.5.0"
 chrono = "0.4.43"
 cpu-time = "1.0.0"
 dashmap = "6.1.0"

--- a/releases/rust/db_esdk/Cargo.toml
+++ b/releases/rust/db_esdk/Cargo.toml
@@ -22,9 +22,11 @@ aws-lc-fips-sys = { version = "0.13", optional = true }
 aws-sdk-dynamodb = "1.103.0"
 aws-sdk-kms = "1.98.0"
 aws-smithy-runtime-api = {version = "1.10.0", features = ["client"] }
-# aws-smithy-types 1.5.0 pulls time 0.3.48 which has a coherence conflict (E0119)
-# with CanDisable<T>'s blanket From impl on rustc >= 1.80. Pin until upstream fixes it.
-aws-smithy-types = ">=1.3.6, <1.5.0"
+# aws-smithy-types has a coherence conflict (E0119) with time >= 0.3.37 on rustc >= 1.80.
+# time 0.3.37+ introduces ModifierValue associated type impls that conflict with
+# CanDisable<T>'s blanket `impl<T> From<T>`. Pin time until upstream fixes it.
+time = ">=0.3.0, <0.3.37"
+aws-smithy-types = "1.3.6"
 chrono = "0.4.43"
 cpu-time = "1.0.0"
 dashmap = "6.1.0"


### PR DESCRIPTION
*Issue #, if available:*
CI is broken.

*Description of changes:*
`smithy-rs` already has a fix in [this commit](https://github.com/smithy-lang/smithy-rs/commit/b5cec4cceb793c0f064cc3bcf04d0a290873b41f)  but not yet released. We should revert this pin after `smithy-rs` releases new version.

`aws-smithy-types` has a coherence conflict (E0119) with time >= 0.3.37 on rustc >= 1.80. time 0.3.37+ introduces ModifierValue associated type impls that conflict with CanDisable<T>'s blanket `impl<T> From<T>`. Pin time until upstream fixes it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
