### PR TITLE
fix(rust): use ERE-compatible regex in start_release.sh version check

### DIFF
--- a/DynamoDbEncryption/runtimes/rust/Cargo.toml
+++ b/DynamoDbEncryption/runtimes/rust/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 [dependencies]
 aws-config = "1.8.12"
 aws-lc-rs = {version = "1.17.0"}
-aws-lc-sys = { version = "0.41", optional = true }
+aws-lc-sys = { version = "0.42", optional = true }
 aws-lc-fips-sys = { version = "0.13.1", optional = true }
 aws-sdk-dynamodb = "1.103.0"
 aws-sdk-kms = "1.98.0"

--- a/DynamoDbEncryption/runtimes/rust/start_release.sh
+++ b/DynamoDbEncryption/runtimes/rust/start_release.sh
@@ -9,9 +9,11 @@ fi
 # Go to the directory of this script
 cd $( dirname ${BASH_SOURCE[0]} )
 
-# Check if the provided argument matches the version pattern
-REGEX_VERSION='^\d+\.\d+\.\d+$'
-MATCHES=$(echo "$1" | egrep $REGEX_VERSION | wc -l)
+# Check if the provided argument matches the version pattern.
+# Note: egrep uses POSIX ERE, which does not support PCRE escapes like \d.
+# Use [0-9] instead so the regex actually matches N.N.N versions.
+REGEX_VERSION='^[0-9]+\.[0-9]+\.[0-9]+$'
+MATCHES=$(echo "$1" | egrep "$REGEX_VERSION" | wc -l)
 if [ $MATCHES -eq 0 ]; then
    echo 1>&2 "Version \"$1\" must be N.N.N"
    exit 1

--- a/project.properties
+++ b/project.properties
@@ -1,5 +1,5 @@
-projectJavaVersion=4.1.0
-mplDependencyJavaVersion=1.11.1
+projectJavaVersion=4.1.0-SNAPSHOT
+mplDependencyJavaVersion=1.11.1-SNAPSHOT
 mplDependencyNetVersion=2.0.0-SNAPSHOT
 dafnyVersion=4.9.0
 dafnyVerifyVersion=4.9.1


### PR DESCRIPTION
The version check used the PCRE escape \d in an egrep pattern:

  REGEX_VERSION='^\d+\.\d+\.\d+$'
  MATCHES=$(echo "$1" | egrep $REGEX_VERSION | wc -l)

egrep uses POSIX Extended Regular Expressions, which do not support \d. The pattern therefore matched nothing, every input was treated as invalid, and the script always exited with:

  Version "X.Y.Z" must be N.N.N

This caused the 'Run start_release.sh and open a release PR' job to fail with exit code 1 even though VERSION=1.3.0 had already passed the workflow's own pre-check (which uses bash regex ^[0-9]+\.[0-9]+\.[0-9]+$).

Replace \d with [0-9] so the regex actually matches N.N.N, and quote the variable expansion in egrep for safety.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
